### PR TITLE
feat: 著者と生年月日を表現するエンティティと値オブジェクトを追加

### DIFF
--- a/domain/src/main/kotlin/com/bookmanagementsystem/domain/author/Author.kt
+++ b/domain/src/main/kotlin/com/bookmanagementsystem/domain/author/Author.kt
@@ -1,0 +1,12 @@
+package com.bookmanagementsystem.domain.author
+
+import com.bookmanagementsystem.domain.core.ID
+
+/**
+ * 著者を表現するエンティティ
+ */
+data class Author(
+    val id: ID<Author>,
+    val name: String,
+    val birthDate: AuthorBirthDate,
+)

--- a/domain/src/main/kotlin/com/bookmanagementsystem/domain/author/AuthorBirthDate.kt
+++ b/domain/src/main/kotlin/com/bookmanagementsystem/domain/author/AuthorBirthDate.kt
@@ -1,0 +1,13 @@
+package com.bookmanagementsystem.domain.author
+
+import java.time.LocalDate
+
+/**
+ * 生年月日を表現する値オブジェクト
+ */
+@JvmInline
+value class AuthorBirthDate(val value: LocalDate) {
+    init {
+        require(value.isBefore(LocalDate.now()))
+    }
+}

--- a/domain/src/main/kotlin/com/bookmanagementsystem/domain/core/ID.kt
+++ b/domain/src/main/kotlin/com/bookmanagementsystem/domain/core/ID.kt
@@ -1,0 +1,12 @@
+package com.bookmanagementsystem.domain.core
+
+/**
+ * エンティティのIDを型安全に表現する値オブジェクト.
+ *
+ * ID<Book> や ID<Author> のように、特定のエンティティに紐づくIDを表現する。
+ */
+data class ID<E>(val value: Int) {
+    init {
+        require(value > 0)
+    }
+}

--- a/domain/src/test/kotlin/com/bookmanagementsystem/domain/author/AuthorBirthDateTest.kt
+++ b/domain/src/test/kotlin/com/bookmanagementsystem/domain/author/AuthorBirthDateTest.kt
@@ -1,0 +1,34 @@
+package com.bookmanagementsystem.domain.author
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import java.time.LocalDate
+
+class AuthorBirthDateTest : FunSpec({
+    test("過去の日付で誕生日を作成できる") {
+        val pastDate = LocalDate.of(1990, 5, 15)
+        val authorBirthDate = AuthorBirthDate(pastDate)
+        authorBirthDate.value shouldBe pastDate
+    }
+
+    test("昨日の日付で誕生日を作成できる") {
+        val yesterday = LocalDate.now().minusDays(1)
+        val authorBirthDate = AuthorBirthDate(yesterday)
+        authorBirthDate.value shouldBe yesterday
+    }
+
+    test("現在日付と等しいときは誕生日を作成できない") {
+        val today = LocalDate.now()
+        shouldThrow<IllegalArgumentException> {
+            AuthorBirthDate(today)
+        }
+    }
+
+    test("現在日付よりも未来の日付で誕生日を作成できない") {
+        val futureDate = LocalDate.now().plusDays(1)
+        shouldThrow<IllegalArgumentException> {
+            AuthorBirthDate(futureDate)
+        }
+    }
+})

--- a/domain/src/test/kotlin/com/bookmanagementsystem/domain/author/AuthorTest.kt
+++ b/domain/src/test/kotlin/com/bookmanagementsystem/domain/author/AuthorTest.kt
@@ -1,0 +1,20 @@
+package com.bookmanagementsystem.domain.author
+
+import com.bookmanagementsystem.domain.core.ID
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import java.time.LocalDate
+
+class AuthorTest : FunSpec({
+    test("有効なパラメータで著者を作成できる") {
+        val authorId = ID<Author>(1)
+        val name = "太宰治"
+        val authorBirthDate = AuthorBirthDate(LocalDate.of(1909, 6, 19))
+
+        val author = Author(authorId, name, authorBirthDate)
+
+        author.id shouldBe authorId
+        author.name shouldBe name
+        author.birthDate shouldBe authorBirthDate
+    }
+})

--- a/domain/src/test/kotlin/com/bookmanagementsystem/domain/core/IDTest.kt
+++ b/domain/src/test/kotlin/com/bookmanagementsystem/domain/core/IDTest.kt
@@ -1,0 +1,24 @@
+package com.bookmanagementsystem.domain.core
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class IDTest : FunSpec({
+    test("有効な正の値でIDを作成できる") {
+        val id = ID<String>(1)
+        id.value shouldBe 1
+    }
+
+    test("0でIDを作成する際は例外が発生する") {
+        shouldThrow<IllegalArgumentException> {
+            ID<String>(0)
+        }
+    }
+
+    test("負の値でIDを作成する際は例外が発生する") {
+        shouldThrow<IllegalArgumentException> {
+            ID<String>(-1)
+        }
+    }
+})

--- a/domain/src/test/kotlin/com/bookmanagementsystem/domain/core/IDTest.kt
+++ b/domain/src/test/kotlin/com/bookmanagementsystem/domain/core/IDTest.kt
@@ -10,13 +10,13 @@ class IDTest : FunSpec({
         id.value shouldBe 1
     }
 
-    test("0でIDを作成する際は例外が発生する") {
+    test("0でIDを作成できない") {
         shouldThrow<IllegalArgumentException> {
             ID<String>(0)
         }
     }
 
-    test("負の値でIDを作成する際は例外が発生する") {
+    test("負の値でIDを作成できない") {
         shouldThrow<IllegalArgumentException> {
             ID<String>(-1)
         }


### PR DESCRIPTION
## 概要
著者と生年月日を表現するエンティティと値オブジェクトを追加し、ドメイン駆動設計の基盤を構築

## 詳細
- IDエンティティ
- Author関連のドメインを作成

## 備考

- [x] テスト実施