### PR TITLE
feat: 著者更新APIのOpenAPIを定義

### DIFF
--- a/presentation/detekt-baseline.xml
+++ b/presentation/detekt-baseline.xml
@@ -5,19 +5,33 @@
     <ID>EmptyClassBlock:AuthorResponseModel.kt$AuthorResponseModel${ }</ID>
     <ID>EmptyClassBlock:BookResponseModel.kt$BookResponseModel${ }</ID>
     <ID>EmptyClassBlock:CreateAuthorRequestModel.kt$CreateAuthorRequestModel${ }</ID>
+    <ID>EmptyClassBlock:ErrorModel.kt$ErrorModel${ }</ID>
+    <ID>EmptyClassBlock:NotFoundErrorResponseModel.kt$NotFoundErrorResponseModel${ }</ID>
+    <ID>EmptyClassBlock:UpdateAuthorRequestModel.kt$UpdateAuthorRequestModel${ }</ID>
     <ID>ImportOrdering:AuthorResponseModel.kt$import com.fasterxml.jackson.annotation.JsonProperty import jakarta.validation.constraints.NotNull import jakarta.validation.constraints.Min import jakarta.validation.constraints.Max import jakarta.validation.Valid</ID>
     <ID>ImportOrdering:BookResponseModel.kt$import com.fasterxml.jackson.annotation.JsonProperty import jakarta.validation.constraints.NotNull import jakarta.validation.constraints.Min import jakarta.validation.constraints.Max import jakarta.validation.Valid</ID>
     <ID>ImportOrdering:CreateAuthorRequestModel.kt$import com.fasterxml.jackson.annotation.JsonProperty import jakarta.validation.constraints.NotNull import jakarta.validation.constraints.Min import jakarta.validation.constraints.Max import jakarta.validation.Valid</ID>
+    <ID>ImportOrdering:ErrorModel.kt$import com.fasterxml.jackson.annotation.JsonProperty import jakarta.validation.constraints.NotNull import jakarta.validation.constraints.Min import jakarta.validation.constraints.Max import jakarta.validation.Valid</ID>
+    <ID>ImportOrdering:NotFoundErrorResponseModel.kt$import com.fasterxml.jackson.annotation.JsonProperty import jakarta.validation.constraints.NotNull import jakarta.validation.constraints.Min import jakarta.validation.constraints.Max import jakarta.validation.Valid</ID>
+    <ID>ImportOrdering:UpdateAuthorRequestModel.kt$import com.fasterxml.jackson.annotation.JsonProperty import jakarta.validation.constraints.NotNull import jakarta.validation.constraints.Min import jakarta.validation.constraints.Max import jakarta.validation.Valid</ID>
     <ID>MagicNumber:BookResponseModel.kt$BookResponseModel$9999999999L</ID>
     <ID>NoBlankLineBeforeRbrace:AuthorResponseModel.kt$AuthorResponseModel$ </ID>
     <ID>NoBlankLineBeforeRbrace:BookResponseModel.kt$BookResponseModel$ </ID>
     <ID>NoBlankLineBeforeRbrace:CreateAuthorRequestModel.kt$CreateAuthorRequestModel$ </ID>
+    <ID>NoBlankLineBeforeRbrace:ErrorModel.kt$ErrorModel$ </ID>
+    <ID>NoBlankLineBeforeRbrace:NotFoundErrorResponseModel.kt$NotFoundErrorResponseModel$ </ID>
+    <ID>NoBlankLineBeforeRbrace:UpdateAuthorRequestModel.kt$UpdateAuthorRequestModel$ </ID>
     <ID>NoConsecutiveBlankLines:BookStatus.kt$BookStatus$ </ID>
     <ID>NoEmptyClassBody:AuthorResponseModel.kt$AuthorResponseModel${ }</ID>
     <ID>NoEmptyClassBody:BookResponseModel.kt$BookResponseModel${ }</ID>
     <ID>NoEmptyClassBody:CreateAuthorRequestModel.kt$CreateAuthorRequestModel${ }</ID>
-    <ID>NoTrailingSpaces:AuthorResponseModel.kt$AuthorResponseModel$ </ID>
+    <ID>NoEmptyClassBody:ErrorModel.kt$ErrorModel${ }</ID>
+    <ID>NoEmptyClassBody:NotFoundErrorResponseModel.kt$NotFoundErrorResponseModel${ }</ID>
+    <ID>NoEmptyClassBody:UpdateAuthorRequestModel.kt$UpdateAuthorRequestModel${ }</ID>
     <ID>NoUnusedImports:AuthorResponseModel.kt$com.bookmanagementsystem.presentation.model.AuthorResponseModel.kt</ID>
     <ID>NoUnusedImports:CreateAuthorRequestModel.kt$com.bookmanagementsystem.presentation.model.CreateAuthorRequestModel.kt</ID>
+    <ID>NoUnusedImports:ErrorModel.kt$com.bookmanagementsystem.presentation.model.ErrorModel.kt</ID>
+    <ID>NoUnusedImports:NotFoundErrorResponseModel.kt$com.bookmanagementsystem.presentation.model.NotFoundErrorResponseModel.kt</ID>
+    <ID>NoUnusedImports:UpdateAuthorRequestModel.kt$com.bookmanagementsystem.presentation.model.UpdateAuthorRequestModel.kt</ID>
   </CurrentIssues>
 </SmellBaseline>

--- a/presentation/src/main/kotlin/com/bookmanagementsystem/presentation/model/ErrorModel.kt
+++ b/presentation/src/main/kotlin/com/bookmanagementsystem/presentation/model/ErrorModel.kt
@@ -1,0 +1,23 @@
+package com.bookmanagementsystem.presentation.model
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.Min
+import jakarta.validation.constraints.Max
+import jakarta.validation.Valid
+
+/**
+ * エラー情報
+ * @param code エラーコード
+ * @param message エラーメッセージ
+ */
+data class ErrorModel(
+
+    /* エラーコード */
+    @get:JsonProperty("code") val code: kotlin.String?,
+
+    /* エラーメッセージ */
+    @get:JsonProperty("message") val message: kotlin.String?
+) {
+
+}

--- a/presentation/src/main/kotlin/com/bookmanagementsystem/presentation/model/NotFoundErrorResponseModel.kt
+++ b/presentation/src/main/kotlin/com/bookmanagementsystem/presentation/model/NotFoundErrorResponseModel.kt
@@ -1,0 +1,17 @@
+package com.bookmanagementsystem.presentation.model
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.Min
+import jakarta.validation.constraints.Max
+import jakarta.validation.Valid
+
+/**
+ * 汎用的なエラーレスポンス
+ */
+data class NotFoundErrorResponseModel(
+    @field:Valid
+    @get:JsonProperty("errors") val errors: kotlin.collections.List<ErrorModel>?
+) {
+
+}

--- a/presentation/src/main/kotlin/com/bookmanagementsystem/presentation/model/UpdateAuthorRequestModel.kt
+++ b/presentation/src/main/kotlin/com/bookmanagementsystem/presentation/model/UpdateAuthorRequestModel.kt
@@ -1,0 +1,25 @@
+package com.bookmanagementsystem.presentation.model
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.Min
+import jakarta.validation.constraints.Max
+import jakarta.validation.Valid
+
+/**
+ * 著者更新APIのリクエスト情報
+ * @param name 著者名
+ * @param birthDate 生年月日
+ */
+data class UpdateAuthorRequestModel(
+
+    /* 著者名 */
+    @field:NotNull
+    @get:JsonProperty("name") val name: kotlin.String?,
+
+    /* 生年月日 */
+    @field:Valid
+    @get:JsonProperty("birthDate") val birthDate: java.time.LocalDate?
+) {
+
+}

--- a/presentation/src/main/resources/openapi.yml
+++ b/presentation/src/main/resources/openapi.yml
@@ -63,6 +63,10 @@ paths:
                 $ref: '#/components/schemas/AuthorResponseModel'
         '404':
           description: 著者が見つからない場合
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFoundErrorResponseModel'
 
 components:
   schemas:
@@ -119,3 +123,25 @@ components:
       required:
         - id
         - name
+
+    NotFoundErrorResponseModel:
+      type: object
+      description: 汎用的なエラーレスポンス
+      properties:
+        errors:
+          type: array
+          items:
+            $ref: '#/components/schemas/ErrorModel'
+
+    ErrorModel:
+      type: object
+      description: エラー情報
+      properties:
+        code:
+          type: string
+          description: エラーコード
+          example: "AUTHOR_NOT_FOUND"
+        message:
+          type: string
+          description: エラーメッセージ
+          example: "指定された著者が見つかりません"

--- a/presentation/src/main/resources/openapi.yml
+++ b/presentation/src/main/resources/openapi.yml
@@ -31,12 +31,60 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AuthorResponseModel'
+  /api/authors/{id}:
+    put:
+      tags:
+        - Authors
+      summary: 著者を更新する
+      operationId: updateAuthor
+      description: |
+        生年月日は現在より過去日付
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: 更新する著者のID
+          schema:
+            type: integer
+            format: int32
+      requestBody:
+        description: 更新する著者の情報
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateAuthorRequestModel'
+      responses:
+        '200':
+          description: 著者の更新に成功
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AuthorResponseModel'
+        '404':
+          description: 著者が見つからない場合
 
 components:
   schemas:
     CreateAuthorRequestModel:
       type: object
       description: 著者登録APIのリクエスト情報
+      properties:
+        name:
+          type: string
+          description: 著者名
+          example: 太宰治
+        birthDate:
+          type: string
+          format: date
+          description: 生年月日
+          example: "1909-06-19"
+      required:
+        - name
+
+    UpdateAuthorRequestModel:
+      type: object
+      description: 著者更新APIのリクエスト情報
       properties:
         name:
           type: string


### PR DESCRIPTION
## 概要
著者更新APIのOpenAPI仕様書とレスポンスモデルを追加

## 詳細 
- OpenAPI仕様書の追加
- レスポンスモデルの追加
- リクエストモデルの追加

## 備考
- バリデーションルール
    - 生年月日: 必須（現在より過去日付）
