### PR TITLE
feat: 著者更新APIの実装

### DIFF
--- a/domain/src/main/kotlin/com/bookmanagementsystem/domain/author/AuthorRepository.kt
+++ b/domain/src/main/kotlin/com/bookmanagementsystem/domain/author/AuthorRepository.kt
@@ -1,8 +1,20 @@
 package com.bookmanagementsystem.domain.author
 
+import com.bookmanagementsystem.domain.core.ID
+
 interface AuthorRepository {
+    /**
+     * IDに合う著者を取得する
+     */
+    fun findById(id: ID<Author>): Author?
+
     /**
      * 著者を登録する
      */
     fun insert(author: Author): Author
+
+    /**
+     * 著者を更新する
+     */
+    fun update(author: Author): Author
 }

--- a/infrastructure/src/main/kotlin/com/bookmanagementsystem/infrastructure/author/AuthorRepositoryImpl.kt
+++ b/infrastructure/src/main/kotlin/com/bookmanagementsystem/infrastructure/author/AuthorRepositoryImpl.kt
@@ -11,10 +11,25 @@ import org.springframework.stereotype.Repository
 
 @Repository
 class AuthorRepositoryImpl(private val dsl: DSLContext) : AuthorRepository {
+    override fun findById(id: ID<Author>): Author? = dsl
+        .selectFrom(AUTHOR)
+        .where(AUTHOR.ID.eq(id.value))
+        .fetchOne()
+        ?.let { convert(it) }
+
     override fun insert(author: Author) = dsl
         .insertInto(AUTHOR)
         .set(AUTHOR.NAME, author.name)
         .set(AUTHOR.BIRTH_DATE, author.birthDate?.value)
+        .returning()
+        .fetchSingle()
+        .let { convert(it) }
+
+    override fun update(author: Author) = dsl
+        .update(AUTHOR)
+        .set(AUTHOR.NAME, author.name)
+        .set(AUTHOR.BIRTH_DATE, author.birthDate?.value)
+        .where(AUTHOR.ID.eq(author.id!!.value))
         .returning()
         .fetchSingle()
         .let { convert(it) }

--- a/presentation/src/main/kotlin/com/bookmanagementsystem/presentation/controller/author/UpdateAuthorController.kt
+++ b/presentation/src/main/kotlin/com/bookmanagementsystem/presentation/controller/author/UpdateAuthorController.kt
@@ -1,0 +1,38 @@
+package com.bookmanagementsystem.presentation.controller.author
+
+import com.bookmanagementsystem.domain.author.AuthorBirthDate
+import com.bookmanagementsystem.domain.core.ID
+import com.bookmanagementsystem.presentation.model.AuthorResponseModel
+import com.bookmanagementsystem.presentation.model.UpdateAuthorRequestModel
+import com.bookmanagementsystem.usecase.author.AuthorDto
+import com.bookmanagementsystem.usecase.author.register.UpdateAuthorCommand
+import com.bookmanagementsystem.usecase.author.register.UpdateAuthorUsecase
+import jakarta.validation.Valid
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class UpdateAuthorController(private val usecase: UpdateAuthorUsecase) {
+    /**
+     * 著者を更新する
+     */
+    @PutMapping("/api/authors/{id}")
+    fun update(@PathVariable id: Int, @Valid @RequestBody request: UpdateAuthorRequestModel): AuthorResponseModel {
+        val dto = usecase.execute(toCommand(id, request))
+        return toResponse(dto)
+    }
+
+    private fun toCommand(id: Int, request: UpdateAuthorRequestModel) = UpdateAuthorCommand(
+        id = ID(id),
+        name = request.name!!,
+        birthDate = request.birthDate?.let { AuthorBirthDate(it) }
+    )
+
+    private fun toResponse(dto: AuthorDto) = AuthorResponseModel(
+        id = dto.id.value,
+        name = dto.name,
+        birthDate = dto.birthDate?.value,
+    )
+}

--- a/presentation/src/main/kotlin/com/bookmanagementsystem/presentation/handler/GlobalExceptionHandler.kt
+++ b/presentation/src/main/kotlin/com/bookmanagementsystem/presentation/handler/GlobalExceptionHandler.kt
@@ -2,6 +2,7 @@ package com.bookmanagementsystem.presentation.handler
 
 import com.bookmanagementsystem.presentation.model.BadRequestErrorResponseModel
 import com.bookmanagementsystem.presentation.model.ErrorModel
+import com.bookmanagementsystem.presentation.model.NotFoundErrorResponseModel
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.MethodArgumentNotValidException
@@ -10,7 +11,6 @@ import org.springframework.web.bind.annotation.RestControllerAdvice
 
 @RestControllerAdvice
 class GlobalExceptionHandler {
-
     @ExceptionHandler(MethodArgumentNotValidException::class)
     fun handleValidationException(ex: MethodArgumentNotValidException): ResponseEntity<BadRequestErrorResponseModel> {
         val errors = ex.bindingResult.fieldErrors.map { fieldError ->
@@ -22,6 +22,18 @@ class GlobalExceptionHandler {
 
         val errorResponse = BadRequestErrorResponseModel(errors = errors)
         return ResponseEntity(errorResponse, HttpStatus.BAD_REQUEST)
+    }
+
+    @ExceptionHandler(NoSuchElementException::class)
+    fun handleNotFound(e: NoSuchElementException): ResponseEntity<NotFoundErrorResponseModel> {
+        val errorModel = ErrorModel(
+            code = "NOT_FOUND",
+            message = e.message ?: "リソースが見つかりません"
+        )
+        val error = NotFoundErrorResponseModel(
+            errors = listOf(errorModel)
+        )
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(error)
     }
 
     @ExceptionHandler(IllegalArgumentException::class)

--- a/presentation/src/test/kotlin/com/bookmanagementsystem/presentation/controller/author/UpdateAuthorControllerTest.kt
+++ b/presentation/src/test/kotlin/com/bookmanagementsystem/presentation/controller/author/UpdateAuthorControllerTest.kt
@@ -1,0 +1,135 @@
+package com.bookmanagementsystem.presentation.controller.author
+
+import com.bookmanagementsystem.presentation.config.IntegrationTestWithSql
+import com.bookmanagementsystem.presentation.model.AuthorResponseModel
+import com.bookmanagementsystem.presentation.model.BadRequestErrorResponseModel
+import com.bookmanagementsystem.presentation.model.NotFoundErrorResponseModel
+import com.bookmanagementsystem.presentation.model.UpdateAuthorRequestModel
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.extensions.spring.SpringExtension
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import org.springframework.web.context.WebApplicationContext
+import java.time.LocalDate
+
+/**
+ * UpdateAuthorController の統合テスト。
+ *
+ * 実際に API を通じて著者更新を行い、バリデーションや正常系の挙動を検証する。
+ * モックではなく実際の環境に近い構成（Spring Boot + MockMvc）で実行される。
+ *
+ * ### 各HTTP ステータスで1パス通せばOK
+ *  context("200") - 正常系：
+ *  context("400") - 異常系：
+ *  context("404") - 存在しない著者：
+ *
+ * 本テストでは、最低限「1パス通ること」で動作確認済みとする。
+ * 異常系・正常系ともに他のテストでカバレッジを確保しており、基本的な入力妥当性を保証する目的。
+ */
+@IntegrationTestWithSql(sqlScript = "UpdateAuthorControllerTest.sql")
+class UpdateAuthorControllerTest : FunSpec() {
+    override fun extensions() = listOf(SpringExtension)
+
+    @Autowired
+    private lateinit var webApplicationContext: WebApplicationContext
+
+    @Autowired
+    private lateinit var objectMapper: ObjectMapper
+    private lateinit var mockMvc: MockMvc
+
+    init {
+        beforeEach {
+            mockMvc = MockMvcBuilders
+                .webAppContextSetup(webApplicationContext)
+                .build()
+        }
+
+        context("200") {
+            test("有効なリクエストで著者が正常に更新される") {
+                val request = UpdateAuthorRequestModel(
+                    name = "更新された夏目漱石",
+                    birthDate = LocalDate.of(1867, 2, 9)
+                )
+                val requestJson = objectMapper.writeValueAsString(request)
+                val result = mockMvc.perform(
+                    put("/api/authors/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestJson)
+                )
+                    .andExpect(status().isOk)
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andReturn()
+
+                // レスポンスボディの検証
+                val responseJson = result.response.contentAsString
+                val response = objectMapper.readValue(responseJson, AuthorResponseModel::class.java)
+
+                response.id shouldBe 1
+                response.name shouldBe "更新された夏目漱石"
+                response.birthDate shouldBe LocalDate.of(1867, 2, 9)
+            }
+        }
+
+        context("400") {
+            test("生年月日が未来日付ならばバリデーションエラーが発生する（JSR-303）") {
+                val request = UpdateAuthorRequestModel(
+                    name = "未来の著者",
+                    birthDate = LocalDate.now().plusDays(1) // 未来日付
+                )
+                val requestJson = objectMapper.writeValueAsString(request)
+
+                val result = mockMvc.perform(
+                    put("/api/authors/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestJson)
+                )
+                    .andExpect(status().isBadRequest)
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andReturn()
+
+                // BadRequestErrorResponseModel形式のレスポンス検証（OpenAPI準拠）
+                val responseJson = result.response.contentAsString
+                val errorResponse = objectMapper.readValue(responseJson, BadRequestErrorResponseModel::class.java)
+
+                errorResponse.errors?.size shouldBe 1
+                errorResponse.errors?.first()?.code shouldBe "VALIDATION_ERROR"
+                errorResponse.errors?.first()?.message shouldBe "birthDate: 生年月日は現在の日付よりも過去である必要があります"
+            }
+        }
+
+        context("404") {
+            test("存在しない著者IDを指定した場合NotFoundErrorResponseModelが返される") {
+                val request = UpdateAuthorRequestModel(
+                    name = "存在しない著者",
+                    birthDate = LocalDate.of(1867, 2, 9)
+                )
+                val requestJson = objectMapper.writeValueAsString(request)
+
+                val result = mockMvc.perform(
+                    put("/api/authors/999")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestJson)
+                )
+                    .andExpect(status().isNotFound)
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andReturn()
+
+                // NotFoundErrorResponseModel形式のレスポンス検証
+                val responseJson = result.response.contentAsString
+                val errorResponse = objectMapper.readValue(responseJson, NotFoundErrorResponseModel::class.java)
+
+                errorResponse.errors?.size shouldBe 1
+                errorResponse.errors?.first()?.code shouldBe "NOT_FOUND"
+                errorResponse.errors?.first()?.message shouldNotBe null
+            }
+        }
+    }
+}

--- a/presentation/src/test/resources/sql/UpdateAuthorControllerTest.sql
+++ b/presentation/src/test/resources/sql/UpdateAuthorControllerTest.sql
@@ -1,0 +1,14 @@
+-- UpdateAuthorControllerTest用のデータベーステストデータ管理
+-- このファイルは @IntegrationTestWithSql アノテーションで実行され、テストの前後でデータをクリーンアップします
+
+-- 著者テーブルのデータをクリーンアップ
+-- book_author テーブルとの外部キー制約がある場合は、そちらから先にクリーンアップ
+DELETE FROM book_author WHERE author_id IS NOT NULL;
+DELETE FROM author;
+
+-- オートインクリメントのシーケンスをリセット
+-- これにより、テスト間でIDが一貫して予測可能になります
+ALTER SEQUENCE author_id_seq RESTART WITH 1;
+
+-- 著者更新テスト用のテストデータを挿入
+INSERT INTO author (id, name, birth_date) VALUES (1, '夏目漱石', '1867-02-09');

--- a/usecase/src/main/kotlin/com/bookmanagementsystem/usecase/author/register/AuthorRegisterCommand.kt
+++ b/usecase/src/main/kotlin/com/bookmanagementsystem/usecase/author/register/AuthorRegisterCommand.kt
@@ -1,6 +1,8 @@
 package com.bookmanagementsystem.usecase.author.register
 
+import com.bookmanagementsystem.domain.author.Author
 import com.bookmanagementsystem.domain.author.AuthorBirthDate
+import com.bookmanagementsystem.domain.core.ID
 
 sealed interface AuthorRegisterCommand
 
@@ -8,6 +10,15 @@ sealed interface AuthorRegisterCommand
  * 著者を登録するコマンド
  */
 data class CreateAuthorCommand(
+    val name: String,
+    val birthDate: AuthorBirthDate?
+) : AuthorRegisterCommand
+
+/**
+ * 著者を更新するコマンド
+ */
+data class UpdateAuthorCommand(
+    val id: ID<Author>,
     val name: String,
     val birthDate: AuthorBirthDate?
 ) : AuthorRegisterCommand

--- a/usecase/src/main/kotlin/com/bookmanagementsystem/usecase/author/register/UpdateAuthorUsecase.kt
+++ b/usecase/src/main/kotlin/com/bookmanagementsystem/usecase/author/register/UpdateAuthorUsecase.kt
@@ -1,0 +1,31 @@
+package com.bookmanagementsystem.usecase.author.register
+
+import com.bookmanagementsystem.domain.author.Author
+import com.bookmanagementsystem.domain.author.AuthorRepository
+import com.bookmanagementsystem.usecase.author.AuthorDto
+import org.springframework.stereotype.Service
+
+@Service
+class UpdateAuthorUsecase(private val repository: AuthorRepository) {
+    /**
+     * 著者を更新する
+     */
+    fun execute(command: UpdateAuthorCommand): AuthorDto {
+        repository.findById(command.id) ?: throw NoSuchElementException("著者が見つかりません: ${command.id}")
+
+        val author = repository.update(toEntity(command))
+        return toDto(author)
+    }
+
+    private fun toEntity(command: UpdateAuthorCommand) = Author(
+        id = command.id,
+        name = command.name,
+        birthDate = command.birthDate
+    )
+
+    private fun toDto(author: Author) = AuthorDto(
+        id = author.id!!,
+        name = author.name,
+        birthDate = author.birthDate
+    )
+}

--- a/usecase/src/test/kotlin/com/bookmanagementsystem/usecase/author/register/UpdateAuthorUsecaseTest.kt
+++ b/usecase/src/test/kotlin/com/bookmanagementsystem/usecase/author/register/UpdateAuthorUsecaseTest.kt
@@ -1,0 +1,122 @@
+package com.bookmanagementsystem.usecase.author.register
+
+import com.bookmanagementsystem.domain.author.Author
+import com.bookmanagementsystem.domain.author.AuthorBirthDate
+import com.bookmanagementsystem.domain.author.AuthorRepository
+import com.bookmanagementsystem.domain.core.ID
+import com.bookmanagementsystem.usecase.author.AuthorDto
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import java.time.LocalDate
+
+class UpdateAuthorUsecaseTest : FunSpec({
+    test("著者更新が正常に実行されること") {
+        val repository = mockk<AuthorRepository>()
+        val usecase = UpdateAuthorUsecase(repository)
+        val authorId = ID<Author>(1)
+        val command = UpdateAuthorCommand(
+            id = authorId,
+            name = "更新後の著者名",
+            birthDate = AuthorBirthDate(LocalDate.of(1985, 5, 15))
+        )
+        val existingAuthor = Author(
+            id = authorId,
+            name = "元の著者名",
+            birthDate = AuthorBirthDate(LocalDate.of(1990, 1, 1))
+        )
+        val updatedAuthor = Author(
+            id = authorId,
+            name = "更新後の著者名",
+            birthDate = AuthorBirthDate(LocalDate.of(1985, 5, 15))
+        )
+
+        every { repository.findById(authorId) } returns existingAuthor
+        every { repository.update(any()) } returns updatedAuthor
+
+        val result = usecase.execute(command)
+        result shouldBe AuthorDto(
+            id = authorId,
+            name = "更新後の著者名",
+            birthDate = AuthorBirthDate(LocalDate.of(1985, 5, 15))
+        )
+        verify {
+            repository.findById(authorId)
+            repository.update(
+                Author(
+                    id = authorId,
+                    name = "更新後の著者名",
+                    birthDate = AuthorBirthDate(LocalDate.of(1985, 5, 15))
+                )
+            )
+        }
+    }
+
+    test("生年月日をnullに更新できること") {
+        val repository = mockk<AuthorRepository>()
+        val usecase = UpdateAuthorUsecase(repository)
+        val authorId = ID<Author>(2)
+        val command = UpdateAuthorCommand(
+            id = authorId,
+            name = "更新後の著者名2",
+            birthDate = null
+        )
+        val existingAuthor = Author(
+            id = authorId,
+            name = "元の著者名2",
+            birthDate = AuthorBirthDate(LocalDate.of(1990, 1, 1))
+        )
+        val updatedAuthor = Author(
+            id = authorId,
+            name = "更新後の著者名2",
+            birthDate = null
+        )
+
+        every { repository.findById(authorId) } returns existingAuthor
+        every { repository.update(any()) } returns updatedAuthor
+
+        val result = usecase.execute(command)
+        result shouldBe AuthorDto(
+            id = authorId,
+            name = "更新後の著者名2",
+            birthDate = null
+        )
+        verify {
+            repository.findById(authorId)
+            repository.update(
+                Author(
+                    id = authorId,
+                    name = "更新後の著者名2",
+                    birthDate = null
+                )
+            )
+        }
+    }
+
+    test("存在しない著者を更新しようとするとNoSuchElementExceptionがスローされること") {
+        val repository = mockk<AuthorRepository>()
+        val usecase = UpdateAuthorUsecase(repository)
+        val authorId = ID<Author>(999)
+        val command = UpdateAuthorCommand(
+            id = authorId,
+            name = "更新後の著者名",
+            birthDate = AuthorBirthDate(LocalDate.of(1985, 5, 15))
+        )
+
+        every { repository.findById(authorId) } returns null
+
+        val exception = shouldThrow<NoSuchElementException> {
+            usecase.execute(command)
+        }
+        exception.message shouldBe "著者が見つかりません: ID(value=999)"
+        verify {
+            repository.findById(authorId)
+        }
+        verify(exactly = 0) {
+            repository.update(any())
+        }
+    }
+})


### PR DESCRIPTION
## 概要
著者の情報を更新するためのRESTful APIを実装

## 詳細
### API仕様
- **エンドポイント**: `PUT /api/authors/{id}`
- **リクエスト**: `UpdateAuthorRequestModel`（名前、生年月日）
- **レスポンス**: `AuthorResponseModel`（更新後の著者情報）
- **エラー**: 400（バリデーション）、404（著者未発見）
- テストの実装
    - UpdateAuthorControllerTest
    - UpdateAuthorUsecaseTest

## 備考
- [x] テスト実施