### PR TITLE
feat: 書籍作成APIのOpenAPI仕様とリクエストモデルを追加

### DIFF
--- a/presentation/detekt-baseline.xml
+++ b/presentation/detekt-baseline.xml
@@ -6,21 +6,27 @@
     <ID>EmptyClassBlock:BadRequestErrorResponseModel.kt$BadRequestErrorResponseModel${ }</ID>
     <ID>EmptyClassBlock:BookResponseModel.kt$BookResponseModel${ }</ID>
     <ID>EmptyClassBlock:CreateAuthorRequestModel.kt$CreateAuthorRequestModel${ }</ID>
+    <ID>EmptyClassBlock:CreateBookRequestModel.kt$CreateBookRequestModel${ }</ID>
     <ID>EmptyClassBlock:ErrorModel.kt$ErrorModel${ }</ID>
     <ID>EmptyClassBlock:NotFoundErrorResponseModel.kt$NotFoundErrorResponseModel${ }</ID>
     <ID>EmptyClassBlock:UpdateAuthorRequestModel.kt$UpdateAuthorRequestModel${ }</ID>
-    <ID>ImportOrdering:AuthorResponseModel.kt$import com.fasterxml.jackson.annotation.JsonProperty import jakarta.validation.constraints.NotNull import jakarta.validation.constraints.Min import jakarta.validation.constraints.Max import jakarta.validation.Valid import com.bookmanagementsystem.usecase.validation.PastOnly</ID>
-    <ID>ImportOrdering:BadRequestErrorResponseModel.kt$import com.fasterxml.jackson.annotation.JsonProperty import jakarta.validation.constraints.NotNull import jakarta.validation.constraints.Min import jakarta.validation.constraints.Max import jakarta.validation.Valid import com.bookmanagementsystem.usecase.validation.PastOnly</ID>
-    <ID>ImportOrdering:BookResponseModel.kt$import com.fasterxml.jackson.annotation.JsonProperty import jakarta.validation.constraints.NotNull import jakarta.validation.constraints.Min import jakarta.validation.constraints.Max import jakarta.validation.Valid</ID>
-    <ID>ImportOrdering:CreateAuthorRequestModel.kt$import com.fasterxml.jackson.annotation.JsonProperty import jakarta.validation.constraints.NotNull import jakarta.validation.constraints.Min import jakarta.validation.constraints.Max import jakarta.validation.Valid import com.bookmanagementsystem.usecase.validation.PastOnly</ID>
-    <ID>ImportOrdering:ErrorModel.kt$import com.fasterxml.jackson.annotation.JsonProperty import jakarta.validation.constraints.NotNull import jakarta.validation.constraints.Min import jakarta.validation.constraints.Max import jakarta.validation.Valid import com.bookmanagementsystem.usecase.validation.PastOnly</ID>
-    <ID>ImportOrdering:NotFoundErrorResponseModel.kt$import com.fasterxml.jackson.annotation.JsonProperty import jakarta.validation.constraints.NotNull import jakarta.validation.constraints.Min import jakarta.validation.constraints.Max import jakarta.validation.Valid import com.bookmanagementsystem.usecase.validation.PastOnly</ID>
-    <ID>ImportOrdering:UpdateAuthorRequestModel.kt$import com.fasterxml.jackson.annotation.JsonProperty import jakarta.validation.constraints.NotNull import jakarta.validation.constraints.Min import jakarta.validation.constraints.Max import jakarta.validation.Valid import com.bookmanagementsystem.usecase.validation.PastOnly</ID>
+    <ID>FinalNewline:CreateBookRequestModelTest.kt$com.bookmanagementsystem.presentation.model.CreateBookRequestModelTest.kt</ID>
+    <ID>ImportOrdering:AuthorResponseModel.kt$import com.fasterxml.jackson.annotation.JsonProperty import jakarta.validation.constraints.NotNull import jakarta.validation.constraints.Min import jakarta.validation.constraints.Max import jakarta.validation.constraints.Size import jakarta.validation.Valid import com.bookmanagementsystem.usecase.validation.PastOnly</ID>
+    <ID>ImportOrdering:BadRequestErrorResponseModel.kt$import com.fasterxml.jackson.annotation.JsonProperty import jakarta.validation.constraints.NotNull import jakarta.validation.constraints.Min import jakarta.validation.constraints.Max import jakarta.validation.constraints.Size import jakarta.validation.Valid import com.bookmanagementsystem.usecase.validation.PastOnly</ID>
+    <ID>ImportOrdering:BookResponseModel.kt$import com.fasterxml.jackson.annotation.JsonProperty import jakarta.validation.constraints.NotNull import jakarta.validation.constraints.Min import jakarta.validation.constraints.Max import jakarta.validation.constraints.Size import jakarta.validation.Valid import com.bookmanagementsystem.usecase.validation.PastOnly</ID>
+    <ID>ImportOrdering:CreateAuthorRequestModel.kt$import com.fasterxml.jackson.annotation.JsonProperty import jakarta.validation.constraints.NotNull import jakarta.validation.constraints.Min import jakarta.validation.constraints.Max import jakarta.validation.constraints.Size import jakarta.validation.Valid import com.bookmanagementsystem.usecase.validation.PastOnly</ID>
+    <ID>ImportOrdering:CreateBookRequestModel.kt$import com.fasterxml.jackson.annotation.JsonProperty import jakarta.validation.constraints.NotNull import jakarta.validation.constraints.Min import jakarta.validation.constraints.Max import jakarta.validation.constraints.Size import jakarta.validation.Valid import com.bookmanagementsystem.usecase.validation.PastOnly</ID>
+    <ID>ImportOrdering:ErrorModel.kt$import com.fasterxml.jackson.annotation.JsonProperty import jakarta.validation.constraints.NotNull import jakarta.validation.constraints.Min import jakarta.validation.constraints.Max import jakarta.validation.constraints.Size import jakarta.validation.Valid import com.bookmanagementsystem.usecase.validation.PastOnly</ID>
+    <ID>ImportOrdering:NotFoundErrorResponseModel.kt$import com.fasterxml.jackson.annotation.JsonProperty import jakarta.validation.constraints.NotNull import jakarta.validation.constraints.Min import jakarta.validation.constraints.Max import jakarta.validation.constraints.Size import jakarta.validation.Valid import com.bookmanagementsystem.usecase.validation.PastOnly</ID>
+    <ID>ImportOrdering:UpdateAuthorRequestModel.kt$import com.fasterxml.jackson.annotation.JsonProperty import jakarta.validation.constraints.NotNull import jakarta.validation.constraints.Min import jakarta.validation.constraints.Max import jakarta.validation.constraints.Size import jakarta.validation.Valid import com.bookmanagementsystem.usecase.validation.PastOnly</ID>
     <ID>MagicNumber:BookResponseModel.kt$BookResponseModel$9999999999L</ID>
+    <ID>MagicNumber:CreateBookRequestModel.kt$CreateBookRequestModel$9999999999L</ID>
+    <ID>NewLineAtEndOfFile:CreateBookRequestModelTest.kt$com.bookmanagementsystem.presentation.model.CreateBookRequestModelTest.kt</ID>
     <ID>NoBlankLineBeforeRbrace:AuthorResponseModel.kt$AuthorResponseModel$ </ID>
     <ID>NoBlankLineBeforeRbrace:BadRequestErrorResponseModel.kt$BadRequestErrorResponseModel$ </ID>
     <ID>NoBlankLineBeforeRbrace:BookResponseModel.kt$BookResponseModel$ </ID>
     <ID>NoBlankLineBeforeRbrace:CreateAuthorRequestModel.kt$CreateAuthorRequestModel$ </ID>
+    <ID>NoBlankLineBeforeRbrace:CreateBookRequestModel.kt$CreateBookRequestModel$ </ID>
     <ID>NoBlankLineBeforeRbrace:ErrorModel.kt$ErrorModel$ </ID>
     <ID>NoBlankLineBeforeRbrace:NotFoundErrorResponseModel.kt$NotFoundErrorResponseModel$ </ID>
     <ID>NoBlankLineBeforeRbrace:UpdateAuthorRequestModel.kt$UpdateAuthorRequestModel$ </ID>
@@ -29,12 +35,15 @@
     <ID>NoEmptyClassBody:BadRequestErrorResponseModel.kt$BadRequestErrorResponseModel${ }</ID>
     <ID>NoEmptyClassBody:BookResponseModel.kt$BookResponseModel${ }</ID>
     <ID>NoEmptyClassBody:CreateAuthorRequestModel.kt$CreateAuthorRequestModel${ }</ID>
+    <ID>NoEmptyClassBody:CreateBookRequestModel.kt$CreateBookRequestModel${ }</ID>
     <ID>NoEmptyClassBody:ErrorModel.kt$ErrorModel${ }</ID>
     <ID>NoEmptyClassBody:NotFoundErrorResponseModel.kt$NotFoundErrorResponseModel${ }</ID>
     <ID>NoEmptyClassBody:UpdateAuthorRequestModel.kt$UpdateAuthorRequestModel${ }</ID>
     <ID>NoUnusedImports:AuthorResponseModel.kt$com.bookmanagementsystem.presentation.model.AuthorResponseModel.kt</ID>
     <ID>NoUnusedImports:BadRequestErrorResponseModel.kt$com.bookmanagementsystem.presentation.model.BadRequestErrorResponseModel.kt</ID>
+    <ID>NoUnusedImports:BookResponseModel.kt$com.bookmanagementsystem.presentation.model.BookResponseModel.kt</ID>
     <ID>NoUnusedImports:CreateAuthorRequestModel.kt$com.bookmanagementsystem.presentation.model.CreateAuthorRequestModel.kt</ID>
+    <ID>NoUnusedImports:CreateBookRequestModel.kt$com.bookmanagementsystem.presentation.model.CreateBookRequestModel.kt</ID>
     <ID>NoUnusedImports:ErrorModel.kt$com.bookmanagementsystem.presentation.model.ErrorModel.kt</ID>
     <ID>NoUnusedImports:NotFoundErrorResponseModel.kt$com.bookmanagementsystem.presentation.model.NotFoundErrorResponseModel.kt</ID>
     <ID>NoUnusedImports:UpdateAuthorRequestModel.kt$com.bookmanagementsystem.presentation.model.UpdateAuthorRequestModel.kt</ID>

--- a/presentation/src/main/kotlin/com/bookmanagementsystem/presentation/model/AuthorResponseModel.kt
+++ b/presentation/src/main/kotlin/com/bookmanagementsystem/presentation/model/AuthorResponseModel.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import jakarta.validation.constraints.NotNull
 import jakarta.validation.constraints.Min
 import jakarta.validation.constraints.Max
+import jakarta.validation.constraints.Size
 import jakarta.validation.Valid
 import com.bookmanagementsystem.usecase.validation.PastOnly
 
@@ -14,7 +15,6 @@ import com.bookmanagementsystem.usecase.validation.PastOnly
  * @param birthDate 生年月日
  */
 data class AuthorResponseModel(
-
     /* 著者ID */
     @field:NotNull
     @get:JsonProperty("id") val id: kotlin.Int?,
@@ -25,6 +25,7 @@ data class AuthorResponseModel(
 
     /* 生年月日 */
     @field:Valid
+    @field:com.bookmanagementsystem.usecase.validation.PastOnly
     @get:JsonProperty("birthDate") val birthDate: java.time.LocalDate?
 ) {
 

--- a/presentation/src/main/kotlin/com/bookmanagementsystem/presentation/model/BadRequestErrorResponseModel.kt
+++ b/presentation/src/main/kotlin/com/bookmanagementsystem/presentation/model/BadRequestErrorResponseModel.kt
@@ -4,11 +4,13 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import jakarta.validation.constraints.NotNull
 import jakarta.validation.constraints.Min
 import jakarta.validation.constraints.Max
+import jakarta.validation.constraints.Size
 import jakarta.validation.Valid
 import com.bookmanagementsystem.usecase.validation.PastOnly
 
 /**
  * リクエストのバリデーションエラー
+ * @param errors kotlin.collections.List<ErrorModel>
  */
 data class BadRequestErrorResponseModel(
     @field:Valid

--- a/presentation/src/main/kotlin/com/bookmanagementsystem/presentation/model/CreateAuthorRequestModel.kt
+++ b/presentation/src/main/kotlin/com/bookmanagementsystem/presentation/model/CreateAuthorRequestModel.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import jakarta.validation.constraints.NotNull
 import jakarta.validation.constraints.Min
 import jakarta.validation.constraints.Max
+import jakarta.validation.constraints.Size
 import jakarta.validation.Valid
 import com.bookmanagementsystem.usecase.validation.PastOnly
 
@@ -13,7 +14,6 @@ import com.bookmanagementsystem.usecase.validation.PastOnly
  * @param birthDate 生年月日
  */
 data class CreateAuthorRequestModel(
-
     /* 著者名 */
     @field:NotNull
     @get:JsonProperty("name") val name: kotlin.String?,

--- a/presentation/src/main/kotlin/com/bookmanagementsystem/presentation/model/CreateBookRequestModel.kt
+++ b/presentation/src/main/kotlin/com/bookmanagementsystem/presentation/model/CreateBookRequestModel.kt
@@ -9,18 +9,13 @@ import jakarta.validation.Valid
 import com.bookmanagementsystem.usecase.validation.PastOnly
 
 /**
- * 書籍のAPIで汎用的に使用するレスポンス情報
- * @param id 書籍ID
+ * 書籍登録APIのリクエスト情報
  * @param title 書籍タイトル
  * @param price 書籍価格
  * @param authors 著者のリスト
  * @param status BookStatus
  */
-data class BookResponseModel(
-    /* 書籍ID */
-    @field:NotNull
-    @get:JsonProperty("id") val id: kotlin.Int?,
-
+data class CreateBookRequestModel(
     /* 書籍タイトル */
     @field:NotNull
     @get:JsonProperty("title") val title: kotlin.String?,

--- a/presentation/src/main/kotlin/com/bookmanagementsystem/presentation/model/ErrorModel.kt
+++ b/presentation/src/main/kotlin/com/bookmanagementsystem/presentation/model/ErrorModel.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import jakarta.validation.constraints.NotNull
 import jakarta.validation.constraints.Min
 import jakarta.validation.constraints.Max
+import jakarta.validation.constraints.Size
 import jakarta.validation.Valid
 import com.bookmanagementsystem.usecase.validation.PastOnly
 
@@ -13,7 +14,6 @@ import com.bookmanagementsystem.usecase.validation.PastOnly
  * @param message エラーメッセージ
  */
 data class ErrorModel(
-
     /* エラーコード */
     @get:JsonProperty("code") val code: kotlin.String?,
 

--- a/presentation/src/main/kotlin/com/bookmanagementsystem/presentation/model/NotFoundErrorResponseModel.kt
+++ b/presentation/src/main/kotlin/com/bookmanagementsystem/presentation/model/NotFoundErrorResponseModel.kt
@@ -4,11 +4,13 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import jakarta.validation.constraints.NotNull
 import jakarta.validation.constraints.Min
 import jakarta.validation.constraints.Max
+import jakarta.validation.constraints.Size
 import jakarta.validation.Valid
 import com.bookmanagementsystem.usecase.validation.PastOnly
 
 /**
  * 汎用的なエラーレスポンス
+ * @param errors kotlin.collections.List<ErrorModel>
  */
 data class NotFoundErrorResponseModel(
     @field:Valid

--- a/presentation/src/main/kotlin/com/bookmanagementsystem/presentation/model/UpdateAuthorRequestModel.kt
+++ b/presentation/src/main/kotlin/com/bookmanagementsystem/presentation/model/UpdateAuthorRequestModel.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import jakarta.validation.constraints.NotNull
 import jakarta.validation.constraints.Min
 import jakarta.validation.constraints.Max
+import jakarta.validation.constraints.Size
 import jakarta.validation.Valid
 import com.bookmanagementsystem.usecase.validation.PastOnly
 
@@ -13,7 +14,6 @@ import com.bookmanagementsystem.usecase.validation.PastOnly
  * @param birthDate 生年月日
  */
 data class UpdateAuthorRequestModel(
-
     /* 著者名 */
     @field:NotNull
     @get:JsonProperty("name") val name: kotlin.String?,

--- a/presentation/src/main/resources/openapi-templates/model.mustache
+++ b/presentation/src/main/resources/openapi-templates/model.mustache
@@ -8,21 +8,22 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import jakarta.validation.constraints.NotNull
 import jakarta.validation.constraints.Min
 import jakarta.validation.constraints.Max
+import jakarta.validation.constraints.Size
 import jakarta.validation.Valid
 import com.bookmanagementsystem.usecase.validation.PastOnly
 {{/isEnum}}
 
 {{#description}}
 /**
- * {{description}}
-{{#hasVars}}{{#vars}}{{#description}} * @param {{name}} {{description}}
-{{/description}}{{/vars}}{{/hasVars}} */
+ * {{{description}}}
+{{#hasVars}}{{#vars}} * @param {{name}}{{#description}} {{{description}}}{{/description}}{{^description}} {{{dataType}}}{{/description}}
+{{/vars}}{{/hasVars}} */
 {{/description}}
 {{^description}}
 /**
  * {{classname}}
-{{#hasVars}}{{#vars}}{{#description}} * @param {{name}} {{description}}
-{{/description}}{{/vars}}{{/hasVars}} */
+{{#hasVars}}{{#vars}} * @param {{name}}{{#description}} {{{description}}}{{/description}}{{^description}} {{{dataType}}}{{/description}}
+{{/vars}}{{/hasVars}} */
 {{/description}}
 {{#isEnum}}
 enum class {{classname}}(@JsonValue val value: {{{dataType}}}) {
@@ -39,15 +40,18 @@ enum class {{classname}}(@JsonValue val value: {{{dataType}}}) {
 {{/isEnum}}
 {{^isEnum}}
 data class {{classname}}(
-{{#vars}}{{#description}}
-    /* {{description}} */
+{{#vars}}{{^-first}}
+
+{{/-first}}{{#description}}    /* {{{description}}} */
 {{/description}}{{#minimum}}    @get:Min({{minimum}}L)
 {{/minimum}}{{#maximum}}    @get:Max({{maximum}}L)
-{{/maximum}}{{#complexType}}    @field:Valid
+{{/maximum}}{{#minItems}}    @get:Size(min = {{minItems}}{{#maxItems}}, max = {{maxItems}}{{/maxItems}})
+{{/minItems}}{{^minItems}}{{#maxItems}}    @get:Size(max = {{maxItems}})
+{{/maxItems}}{{/minItems}}{{#complexType}}    @field:Valid
 {{/complexType}}{{#vendorExtensions.x-field-extra-annotation}}    {{vendorExtensions.x-field-extra-annotation}}
 {{/vendorExtensions.x-field-extra-annotation}}{{#required}}    @field:NotNull
-{{/required}}    @get:JsonProperty("{{baseName}}") val {{name}}: {{{dataType}}}?{{^-last}},{{/-last}}
-{{/vars}}) {
+{{/required}}    @get:JsonProperty("{{baseName}}") val {{name}}: {{{dataType}}}?{{^-last}},{{/-last}}{{/vars}}
+) {
 
 }
 {{/isEnum}}

--- a/presentation/src/main/resources/openapi.yml
+++ b/presentation/src/main/resources/openapi.yml
@@ -81,6 +81,37 @@ paths:
               schema:
                 $ref: '#/components/schemas/NotFoundErrorResponseModel'
 
+  /api/books:
+    post:
+      tags:
+        - Books
+      summary: 書籍を作成する
+      operationId: createBook
+      description: |
+        - 書籍価格は0以上
+        - 著者は1人以上
+        - 出版ステータスは出版済みから未出版に変更できない
+      requestBody:
+        description: 登録する著者の情報
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateBookRequestModel'
+      responses:
+        '200':
+          description: 著者の作成に成功
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AuthorResponseModel'
+        '400':
+          description: リクエストのバリデーションエラー
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BadRequestErrorResponseModel'
+
 components:
   schemas:
     CreateAuthorRequestModel:
@@ -117,6 +148,35 @@ components:
       required:
         - name
 
+    CreateBookRequestModel:
+      type: object
+      description: 書籍登録APIのリクエスト情報
+      properties:
+        title:
+          type: string
+          description: 書籍タイトル
+          example: "人間失格"
+        price:
+          type: integer
+          format: int64
+          minimum: 0
+          maximum: 9999999999
+          description: 書籍価格
+          example: 1500
+        authors:
+          type: array
+          minItems: 1
+          items:
+            $ref: '#/components/schemas/AuthorResponseModel'
+          description: 著者のリスト
+        status:
+          $ref: '#/components/schemas/BookStatus'
+      required:
+        - title
+        - price
+        - authors
+        - status
+
     AuthorResponseModel:
       type: object
       description: 著者のAPIで汎用的に使用するレスポンス情報
@@ -134,10 +194,58 @@ components:
           type: string
           format: date
           description: 生年月日
+          x-field-extra-annotation: "@field:com.bookmanagementsystem.usecase.validation.PastOnly"
           example: "1909-06-19"
       required:
         - id
         - name
+
+    BookResponseModel:
+      type: object
+      description: 書籍のAPIで汎用的に使用するレスポンス情報
+      properties:
+        id:
+          type: integer
+          format: int32
+          description: 書籍ID
+          example: 1
+        title:
+          type: string
+          description: 書籍タイトル
+          example: "人間失格"
+        price:
+          type: integer
+          format: int64
+          minimum: 0
+          maximum: 9999999999
+          description: 書籍価格
+          example: 1500
+        authors:
+          type: array
+          minItems: 1
+          items:
+            $ref: '#/components/schemas/AuthorResponseModel'
+          description: 著者のリスト
+        status:
+          $ref: '#/components/schemas/BookStatus'
+      required:
+        - id
+        - title
+        - price
+        - authors
+        - status
+
+    BookStatus:
+      type: integer
+      format: int32
+      description: 出版ステータス
+      enum:
+        - 1
+        - 2
+      example: 1
+      x-enum-varnames:
+        - PUBLISHED
+        - UNPUBLISHED
 
     BadRequestErrorResponseModel:
       type: object

--- a/presentation/src/main/resources/openapi.yml
+++ b/presentation/src/main/resources/openapi.yml
@@ -92,7 +92,7 @@ paths:
         - 著者は1人以上
         - 出版ステータスは出版済みから未出版に変更できない
       requestBody:
-        description: 登録する著者の情報
+        description: 登録する書籍の情報
         required: true
         content:
           application/json:
@@ -100,11 +100,11 @@ paths:
               $ref: '#/components/schemas/CreateBookRequestModel'
       responses:
         '200':
-          description: 著者の作成に成功
+          description: 書籍の作成に成功
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AuthorResponseModel'
+                $ref: '#/components/schemas/BookResponseModel'
         '400':
           description: リクエストのバリデーションエラー
           content:

--- a/presentation/src/test/kotlin/com/bookmanagementsystem/presentation/model/CreateBookRequestModelTest.kt
+++ b/presentation/src/test/kotlin/com/bookmanagementsystem/presentation/model/CreateBookRequestModelTest.kt
@@ -13,16 +13,10 @@ class CreateBookRequestModelTest : FunSpec({
     test("有効なパラメータでCreateBookRequestModelを作成できる") {
         val title = "人間失格"
         val price = 1500L
-        val authors = listOf(
-            AuthorResponseModel(
-                id = 1,
-                name = "太宰治",
-                birthDate = LocalDate.of(1909, 6, 19)
-            )
-        )
+        val authors = createDefaultAuthors()
         val status = BookStatus.PUBLISHED
 
-        val requestModel = CreateBookRequestModel(
+        val requestModel = createValidBookRequest(
             title = title,
             price = price,
             authors = authors,
@@ -39,13 +33,7 @@ class CreateBookRequestModelTest : FunSpec({
         val requestModel = CreateBookRequestModel(
             title = null,
             price = 1500L,
-            authors = listOf(
-                AuthorResponseModel(
-                    id = 1,
-                    name = "太宰治",
-                    birthDate = LocalDate.of(1909, 6, 19)
-                )
-            ),
+            authors = createDefaultAuthors(),
             status = BookStatus.PUBLISHED
         )
 
@@ -58,13 +46,7 @@ class CreateBookRequestModelTest : FunSpec({
         val requestModel = CreateBookRequestModel(
             title = "人間失格",
             price = null,
-            authors = listOf(
-                AuthorResponseModel(
-                    id = 1,
-                    name = "太宰治",
-                    birthDate = LocalDate.of(1909, 6, 19)
-                )
-            ),
+            authors = createDefaultAuthors(),
             status = BookStatus.PUBLISHED
         )
 
@@ -74,17 +56,8 @@ class CreateBookRequestModelTest : FunSpec({
     }
 
     test("価格が負の値の場合バリデーションエラー") {
-        val requestModel = CreateBookRequestModel(
-            title = "人間失格",
-            price = -1L,
-            authors = listOf(
-                AuthorResponseModel(
-                    id = 1,
-                    name = "太宰治",
-                    birthDate = LocalDate.of(1909, 6, 19)
-                )
-            ),
-            status = BookStatus.PUBLISHED
+        val requestModel = createValidBookRequest(
+            price = -1L
         )
 
         val violations = validator.validate(requestModel)
@@ -93,17 +66,8 @@ class CreateBookRequestModelTest : FunSpec({
     }
 
     test("価格が最大値を超える場合バリデーションエラー") {
-        val requestModel = CreateBookRequestModel(
-            title = "人間失格",
-            price = 10000000000L,
-            authors = listOf(
-                AuthorResponseModel(
-                    id = 1,
-                    name = "太宰治",
-                    birthDate = LocalDate.of(1909, 6, 19)
-                )
-            ),
-            status = BookStatus.PUBLISHED
+        val requestModel = createValidBookRequest(
+            price = 10000000000L
         )
 
         val violations = validator.validate(requestModel)
@@ -125,11 +89,8 @@ class CreateBookRequestModelTest : FunSpec({
     }
 
     test("著者リストが空の場合バリデーションエラー") {
-        val requestModel = CreateBookRequestModel(
-            title = "人間失格",
-            price = 1500L,
-            authors = emptyList(),
-            status = BookStatus.PUBLISHED
+        val requestModel = createValidBookRequest(
+            authors = emptyList()
         )
 
         val violations = validator.validate(requestModel)
@@ -141,13 +102,7 @@ class CreateBookRequestModelTest : FunSpec({
         val requestModel = CreateBookRequestModel(
             title = "人間失格",
             price = 1500L,
-            authors = listOf(
-                AuthorResponseModel(
-                    id = 1,
-                    name = "太宰治",
-                    birthDate = LocalDate.of(1909, 6, 19)
-                )
-            ),
+            authors = createDefaultAuthors(),
             status = null
         )
 
@@ -158,23 +113,14 @@ class CreateBookRequestModelTest : FunSpec({
 
     test("複数の著者を設定できる") {
         val authors = listOf(
-            AuthorResponseModel(
-                id = 1,
-                name = "太宰治",
-                birthDate = LocalDate.of(1909, 6, 19)
-            ),
-            AuthorResponseModel(
-                id = 2,
-                name = "夏目漱石",
-                birthDate = LocalDate.of(1867, 2, 9)
-            )
+            createDefaultAuthor(id = 1, name = "太宰治"),
+            createDefaultAuthor(id = 2, name = "夏目漱石", birthDate = LocalDate.of(1867, 2, 9))
         )
 
-        val requestModel = CreateBookRequestModel(
+        val requestModel = createValidBookRequest(
             title = "文学選集",
             price = 3000L,
-            authors = authors,
-            status = BookStatus.PUBLISHED
+            authors = authors
         )
 
         requestModel.authors?.shouldHaveSize(2)
@@ -182,16 +128,7 @@ class CreateBookRequestModelTest : FunSpec({
     }
 
     test("出版済みステータスを設定できる") {
-        val requestModel = CreateBookRequestModel(
-            title = "人間失格",
-            price = 1500L,
-            authors = listOf(
-                AuthorResponseModel(
-                    id = 1,
-                    name = "太宰治",
-                    birthDate = LocalDate.of(1909, 6, 19)
-                )
-            ),
+        val requestModel = createValidBookRequest(
             status = BookStatus.PUBLISHED
         )
 
@@ -200,16 +137,7 @@ class CreateBookRequestModelTest : FunSpec({
     }
 
     test("未出版ステータスを設定できる") {
-        val requestModel = CreateBookRequestModel(
-            title = "人間失格",
-            price = 1500L,
-            authors = listOf(
-                AuthorResponseModel(
-                    id = 1,
-                    name = "太宰治",
-                    birthDate = LocalDate.of(1909, 6, 19)
-                )
-            ),
+        val requestModel = createValidBookRequest(
             status = BookStatus.UNPUBLISHED
         )
 
@@ -218,17 +146,9 @@ class CreateBookRequestModelTest : FunSpec({
     }
 
     test("価格の境界値テスト - 最小値0") {
-        val requestModel = CreateBookRequestModel(
+        val requestModel = createValidBookRequest(
             title = "無料本",
-            price = 0L,
-            authors = listOf(
-                AuthorResponseModel(
-                    id = 1,
-                    name = "太宰治",
-                    birthDate = LocalDate.of(1909, 6, 19)
-                )
-            ),
-            status = BookStatus.PUBLISHED
+            price = 0L
         )
 
         val violations = validator.validate(requestModel)
@@ -236,20 +156,37 @@ class CreateBookRequestModelTest : FunSpec({
     }
 
     test("価格の境界値テスト - 最大値9999999999") {
-        val requestModel = CreateBookRequestModel(
+        val requestModel = createValidBookRequest(
             title = "高額本",
-            price = 9999999999L,
-            authors = listOf(
-                AuthorResponseModel(
-                    id = 1,
-                    name = "太宰治",
-                    birthDate = LocalDate.of(1909, 6, 19)
-                )
-            ),
-            status = BookStatus.PUBLISHED
+            price = 9999999999L
         )
 
         val violations = validator.validate(requestModel)
         violations shouldHaveSize 0
     }
 })
+
+// テストフィクスチャ
+fun createDefaultAuthor(
+    id: Int = 1,
+    name: String = "太宰治",
+    birthDate: LocalDate = LocalDate.of(1909, 6, 19)
+) = AuthorResponseModel(
+    id = id,
+    name = name,
+    birthDate = birthDate
+)
+
+fun createDefaultAuthors() = listOf(createDefaultAuthor())
+
+fun createValidBookRequest(
+    title: String = "人間失格",
+    price: Long = 1500L,
+    authors: List<AuthorResponseModel> = createDefaultAuthors(),
+    status: BookStatus = BookStatus.PUBLISHED
+) = CreateBookRequestModel(
+    title = title,
+    price = price,
+    authors = authors,
+    status = status
+)

--- a/presentation/src/test/kotlin/com/bookmanagementsystem/presentation/model/CreateBookRequestModelTest.kt
+++ b/presentation/src/test/kotlin/com/bookmanagementsystem/presentation/model/CreateBookRequestModelTest.kt
@@ -1,0 +1,255 @@
+package com.bookmanagementsystem.presentation.model
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import jakarta.validation.Validation
+import jakarta.validation.Validator
+import java.time.LocalDate
+
+class CreateBookRequestModelTest : FunSpec({
+    val validator: Validator = Validation.buildDefaultValidatorFactory().validator
+
+    test("有効なパラメータでCreateBookRequestModelを作成できる") {
+        val title = "人間失格"
+        val price = 1500L
+        val authors = listOf(
+            AuthorResponseModel(
+                id = 1,
+                name = "太宰治",
+                birthDate = LocalDate.of(1909, 6, 19)
+            )
+        )
+        val status = BookStatus.PUBLISHED
+
+        val requestModel = CreateBookRequestModel(
+            title = title,
+            price = price,
+            authors = authors,
+            status = status
+        )
+
+        requestModel.title shouldBe title
+        requestModel.price shouldBe price
+        requestModel.authors shouldBe authors
+        requestModel.status shouldBe status
+    }
+
+    test("タイトルがnullの場合バリデーションエラー") {
+        val requestModel = CreateBookRequestModel(
+            title = null,
+            price = 1500L,
+            authors = listOf(
+                AuthorResponseModel(
+                    id = 1,
+                    name = "太宰治",
+                    birthDate = LocalDate.of(1909, 6, 19)
+                )
+            ),
+            status = BookStatus.PUBLISHED
+        )
+
+        val violations = validator.validate(requestModel)
+        violations shouldHaveSize 1
+        violations.first().messageTemplate shouldBe "{jakarta.validation.constraints.NotNull.message}"
+    }
+
+    test("価格がnullの場合バリデーションエラー") {
+        val requestModel = CreateBookRequestModel(
+            title = "人間失格",
+            price = null,
+            authors = listOf(
+                AuthorResponseModel(
+                    id = 1,
+                    name = "太宰治",
+                    birthDate = LocalDate.of(1909, 6, 19)
+                )
+            ),
+            status = BookStatus.PUBLISHED
+        )
+
+        val violations = validator.validate(requestModel)
+        violations shouldHaveSize 1
+        violations.first().messageTemplate shouldBe "{jakarta.validation.constraints.NotNull.message}"
+    }
+
+    test("価格が負の値の場合バリデーションエラー") {
+        val requestModel = CreateBookRequestModel(
+            title = "人間失格",
+            price = -1L,
+            authors = listOf(
+                AuthorResponseModel(
+                    id = 1,
+                    name = "太宰治",
+                    birthDate = LocalDate.of(1909, 6, 19)
+                )
+            ),
+            status = BookStatus.PUBLISHED
+        )
+
+        val violations = validator.validate(requestModel)
+        violations shouldHaveSize 1
+        violations.first().messageTemplate shouldBe "{jakarta.validation.constraints.Min.message}"
+    }
+
+    test("価格が最大値を超える場合バリデーションエラー") {
+        val requestModel = CreateBookRequestModel(
+            title = "人間失格",
+            price = 10000000000L,
+            authors = listOf(
+                AuthorResponseModel(
+                    id = 1,
+                    name = "太宰治",
+                    birthDate = LocalDate.of(1909, 6, 19)
+                )
+            ),
+            status = BookStatus.PUBLISHED
+        )
+
+        val violations = validator.validate(requestModel)
+        violations shouldHaveSize 1
+        violations.first().messageTemplate shouldBe "{jakarta.validation.constraints.Max.message}"
+    }
+
+    test("著者リストがnullの場合バリデーションエラー") {
+        val requestModel = CreateBookRequestModel(
+            title = "人間失格",
+            price = 1500L,
+            authors = null,
+            status = BookStatus.PUBLISHED
+        )
+
+        val violations = validator.validate(requestModel)
+        violations shouldHaveSize 1
+        violations.first().messageTemplate shouldBe "{jakarta.validation.constraints.NotNull.message}"
+    }
+
+    test("著者リストが空の場合バリデーションエラー") {
+        val requestModel = CreateBookRequestModel(
+            title = "人間失格",
+            price = 1500L,
+            authors = emptyList(),
+            status = BookStatus.PUBLISHED
+        )
+
+        val violations = validator.validate(requestModel)
+        violations shouldHaveSize 1
+        violations.first().messageTemplate shouldBe "{jakarta.validation.constraints.Size.message}"
+    }
+
+    test("ステータスがnullの場合バリデーションエラー") {
+        val requestModel = CreateBookRequestModel(
+            title = "人間失格",
+            price = 1500L,
+            authors = listOf(
+                AuthorResponseModel(
+                    id = 1,
+                    name = "太宰治",
+                    birthDate = LocalDate.of(1909, 6, 19)
+                )
+            ),
+            status = null
+        )
+
+        val violations = validator.validate(requestModel)
+        violations shouldHaveSize 1
+        violations.first().messageTemplate shouldBe "{jakarta.validation.constraints.NotNull.message}"
+    }
+
+    test("複数の著者を設定できる") {
+        val authors = listOf(
+            AuthorResponseModel(
+                id = 1,
+                name = "太宰治",
+                birthDate = LocalDate.of(1909, 6, 19)
+            ),
+            AuthorResponseModel(
+                id = 2,
+                name = "夏目漱石",
+                birthDate = LocalDate.of(1867, 2, 9)
+            )
+        )
+
+        val requestModel = CreateBookRequestModel(
+            title = "文学選集",
+            price = 3000L,
+            authors = authors,
+            status = BookStatus.PUBLISHED
+        )
+
+        requestModel.authors?.shouldHaveSize(2)
+        requestModel.authors shouldBe authors
+    }
+
+    test("出版済みステータスを設定できる") {
+        val requestModel = CreateBookRequestModel(
+            title = "人間失格",
+            price = 1500L,
+            authors = listOf(
+                AuthorResponseModel(
+                    id = 1,
+                    name = "太宰治",
+                    birthDate = LocalDate.of(1909, 6, 19)
+                )
+            ),
+            status = BookStatus.PUBLISHED
+        )
+
+        requestModel.status shouldBe BookStatus.PUBLISHED
+        requestModel.status?.value shouldBe 1
+    }
+
+    test("未出版ステータスを設定できる") {
+        val requestModel = CreateBookRequestModel(
+            title = "人間失格",
+            price = 1500L,
+            authors = listOf(
+                AuthorResponseModel(
+                    id = 1,
+                    name = "太宰治",
+                    birthDate = LocalDate.of(1909, 6, 19)
+                )
+            ),
+            status = BookStatus.UNPUBLISHED
+        )
+
+        requestModel.status shouldBe BookStatus.UNPUBLISHED
+        requestModel.status?.value shouldBe 2
+    }
+
+    test("価格の境界値テスト - 最小値0") {
+        val requestModel = CreateBookRequestModel(
+            title = "無料本",
+            price = 0L,
+            authors = listOf(
+                AuthorResponseModel(
+                    id = 1,
+                    name = "太宰治",
+                    birthDate = LocalDate.of(1909, 6, 19)
+                )
+            ),
+            status = BookStatus.PUBLISHED
+        )
+
+        val violations = validator.validate(requestModel)
+        violations shouldHaveSize 0
+    }
+
+    test("価格の境界値テスト - 最大値9999999999") {
+        val requestModel = CreateBookRequestModel(
+            title = "高額本",
+            price = 9999999999L,
+            authors = listOf(
+                AuthorResponseModel(
+                    id = 1,
+                    name = "太宰治",
+                    birthDate = LocalDate.of(1909, 6, 19)
+                )
+            ),
+            status = BookStatus.PUBLISHED
+        )
+
+        val violations = validator.validate(requestModel)
+        violations shouldHaveSize 0
+    }
+})


### PR DESCRIPTION
## 概要
書籍作成APIのOpenAPI仕様を定義し、関連するリクエストモデルとテストを実装

## 詳細
### リクエストモデル仕様
- **title**: 書籍タイトル（必須）
- **price**: 書籍価格（0〜9,999,999,999円）
- **authors**: 著者のリスト（最低1名必須）
- **status**: 書籍ステータス（必須）

### テスト実装
- `CreateBookRequestModelTest` - リクエストモデルのバリデーションテスト
- 正常系・異常系のテストケース追加

## 備考
- [x] テスト実施