### PR TITLE
feat: 書籍作成APIの実装

### DIFF
--- a/domain/src/main/kotlin/com/bookmanagementsystem/domain/book/Book.kt
+++ b/domain/src/main/kotlin/com/bookmanagementsystem/domain/book/Book.kt
@@ -7,11 +7,11 @@ import com.bookmanagementsystem.domain.core.ID
  * 書籍を表現するエンティティ
  */
 data class Book(
-    val id: ID<Book>,
+    val id: ID<Book>? = null,
     val title: String,
     val price: BookPrice,
-    val status: BookPublishStatus,
     val authorIds: List<ID<Author>>,
+    val status: BookPublishStatus,
 ) {
     init {
         require(authorIds.isNotEmpty())

--- a/domain/src/main/kotlin/com/bookmanagementsystem/domain/book/BookPrice.kt
+++ b/domain/src/main/kotlin/com/bookmanagementsystem/domain/book/BookPrice.kt
@@ -13,6 +13,8 @@ data class BookPrice(val amount: Amount) {
 
     companion object {
         fun of(amount: Long): BookPrice = BookPrice(Amount.of(amount))
+
+        fun of(amount: BigDecimal): BookPrice = BookPrice(Amount(amount))
     }
 
     fun toLong(): Long = amount.toLong()

--- a/domain/src/main/kotlin/com/bookmanagementsystem/domain/book/BookRepository.kt
+++ b/domain/src/main/kotlin/com/bookmanagementsystem/domain/book/BookRepository.kt
@@ -1,0 +1,11 @@
+package com.bookmanagementsystem.domain.book
+
+/**
+ * 書籍のリポジトリインターフェース
+ */
+interface BookRepository {
+    /**
+     * 書籍を登録する
+     */
+    fun insert(book: Book): Book
+}

--- a/domain/src/test/kotlin/com/bookmanagementsystem/domain/book/BookPriceTest.kt
+++ b/domain/src/test/kotlin/com/bookmanagementsystem/domain/book/BookPriceTest.kt
@@ -20,7 +20,7 @@ class BookPriceTest : FunSpec({
 
         test("負の金額で書籍価格を作成できない") {
             shouldThrow<IllegalArgumentException> {
-                BookPrice(Amount.of(-100L))
+                BookPrice.of(-100L)
             }
         }
 
@@ -31,8 +31,7 @@ class BookPriceTest : FunSpec({
         }
 
         test("小数を含む書籍金額で価格を作成できる") {
-            val amount = Amount(BigDecimal("1500.50"))
-            val price = BookPrice(amount)
+            val price = BookPrice.of(BigDecimal("1500.50"))
             price.amount.value shouldBe BigDecimal("1500.50")
         }
     }

--- a/domain/src/test/kotlin/com/bookmanagementsystem/domain/book/BookTest.kt
+++ b/domain/src/test/kotlin/com/bookmanagementsystem/domain/book/BookTest.kt
@@ -14,7 +14,7 @@ class BookTest : FunSpec({
         val status = BookPublishStatus.PUBLISHED
         val authorIds: List<ID<Author>> = listOf(ID(1))
 
-        val book = Book(bookId, title, price, status, authorIds)
+        val book = Book(bookId, title, price, authorIds, status)
 
         book.id shouldBe bookId
         book.title shouldBe title
@@ -30,7 +30,7 @@ class BookTest : FunSpec({
         val status = BookPublishStatus.UNPUBLISHED
         val authorIds: List<ID<Author>> = listOf(ID(1), ID(2), ID(3))
 
-        val book = Book(bookId, title, price, status, authorIds)
+        val book = Book(bookId, title, price, authorIds, status)
 
         book.authorIds.size shouldBe 3
         book.authorIds shouldBe authorIds
@@ -44,7 +44,7 @@ class BookTest : FunSpec({
         val authorIds: List<ID<Author>> = emptyList()
 
         shouldThrow<IllegalArgumentException> {
-            Book(bookId, title, price, status, authorIds)
+            Book(bookId, title, price, authorIds, status)
         }
     }
 })

--- a/infrastructure/src/main/kotlin/com/bookmanagementsystem/infrastructure/author/AuthorQueryServiceImpl.kt
+++ b/infrastructure/src/main/kotlin/com/bookmanagementsystem/infrastructure/author/AuthorQueryServiceImpl.kt
@@ -1,0 +1,33 @@
+package com.bookmanagementsystem.infrastructure.author
+
+import com.bookmanagementsystem.domain.author.AuthorBirthDate
+import com.bookmanagementsystem.domain.book.Book
+import com.bookmanagementsystem.domain.core.ID
+import com.bookmanagementsystem.jooq.tables.references.AUTHOR
+import com.bookmanagementsystem.jooq.tables.references.BOOK_AUTHOR
+import com.bookmanagementsystem.usecase.author.AuthorDto
+import com.bookmanagementsystem.usecase.author.read.AuthorQueryService
+import org.jooq.DSLContext
+import org.springframework.stereotype.Repository
+
+@Repository
+class AuthorQueryServiceImpl(private val dsl: DSLContext) : AuthorQueryService {
+    override fun findByBookId(bookId: ID<Book>) = dsl
+        .select(
+            AUTHOR.ID,
+            AUTHOR.NAME,
+            AUTHOR.BIRTH_DATE,
+        )
+        .from(AUTHOR)
+        .join(BOOK_AUTHOR)
+        .on(AUTHOR.ID.eq(BOOK_AUTHOR.AUTHOR_ID))
+        .where(BOOK_AUTHOR.BOOK_ID.eq(bookId.value))
+        .fetch()
+        .map { record ->
+            AuthorDto(
+                id = ID(record[AUTHOR.ID]!!),
+                name = record[AUTHOR.NAME]!!,
+                birthDate = record[AUTHOR.BIRTH_DATE]?.let { AuthorBirthDate(it) }
+            )
+        }
+}

--- a/infrastructure/src/main/kotlin/com/bookmanagementsystem/infrastructure/book/BookRepositoryImpl.kt
+++ b/infrastructure/src/main/kotlin/com/bookmanagementsystem/infrastructure/book/BookRepositoryImpl.kt
@@ -1,0 +1,47 @@
+package com.bookmanagementsystem.infrastructure.book
+
+import com.bookmanagementsystem.domain.author.Author
+import com.bookmanagementsystem.domain.book.Book
+import com.bookmanagementsystem.domain.book.BookPrice
+import com.bookmanagementsystem.domain.book.BookPublishStatus
+import com.bookmanagementsystem.domain.book.BookRepository
+import com.bookmanagementsystem.domain.core.ID
+import com.bookmanagementsystem.jooq.tables.records.BookRecord
+import com.bookmanagementsystem.jooq.tables.references.BOOK
+import com.bookmanagementsystem.jooq.tables.references.BOOK_AUTHOR
+import org.jooq.DSLContext
+import org.springframework.stereotype.Repository
+
+@Repository
+class BookRepositoryImpl(private val dsl: DSLContext) : BookRepository {
+    override fun insert(book: Book): Book {
+        val record = dsl.insertInto(BOOK)
+            .set(BOOK.TITLE, book.title)
+            .set(BOOK.PRICE, book.price.amount.value)
+            .set(BOOK.PUBLISH_STATUS, book.status.value)
+            .returning()
+            .fetchSingle()
+
+        val authorIds = insertBookAuthor(ID(record.id!!), book.authorIds)
+        return convert(record, authorIds)
+    }
+
+    private fun insertBookAuthor(bookId: ID<Book>, authorIds: List<ID<Author>>): List<ID<Author>> = dsl
+        .insertInto(
+            BOOK_AUTHOR,
+            BOOK_AUTHOR.BOOK_ID,
+            BOOK_AUTHOR.AUTHOR_ID
+        )
+        .apply { authorIds.forEach { values(bookId.value, it.value) } }
+        .returning()
+        .fetch()
+        .map { ID(it[BOOK_AUTHOR.AUTHOR_ID]!!) }
+
+    private fun convert(record: BookRecord, authorIds: List<ID<Author>>) = Book(
+        id = ID(record.id!!),
+        title = record.title!!,
+        price = BookPrice.of(record.price!!),
+        authorIds = authorIds,
+        status = BookPublishStatus.of(record.publishStatus!!),
+    )
+}

--- a/presentation/src/main/kotlin/com/bookmanagementsystem/presentation/controller/book/CreateBookController.kt
+++ b/presentation/src/main/kotlin/com/bookmanagementsystem/presentation/controller/book/CreateBookController.kt
@@ -1,0 +1,49 @@
+package com.bookmanagementsystem.presentation.controller.book
+
+import com.bookmanagementsystem.domain.book.BookPrice
+import com.bookmanagementsystem.domain.book.BookPublishStatus
+import com.bookmanagementsystem.domain.core.ID
+import com.bookmanagementsystem.presentation.model.AuthorResponseModel
+import com.bookmanagementsystem.presentation.model.BookResponseModel
+import com.bookmanagementsystem.presentation.model.BookStatus
+import com.bookmanagementsystem.presentation.model.CreateBookRequestModel
+import com.bookmanagementsystem.usecase.book.BookDto
+import com.bookmanagementsystem.usecase.book.register.CreateBookCommand
+import com.bookmanagementsystem.usecase.book.register.CreateBookUsecase
+import jakarta.validation.Valid
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class CreateBookController(private val usecase: CreateBookUsecase) {
+    /**
+     * 書籍を登録する
+     */
+    @PostMapping("/api/books")
+    fun create(@Valid @RequestBody request: CreateBookRequestModel): BookResponseModel {
+        val dto = usecase.execute(toCommand(request))
+        return toResponse(dto)
+    }
+
+    private fun toCommand(request: CreateBookRequestModel) = CreateBookCommand(
+        title = request.title!!,
+        price = BookPrice.of(request.price!!),
+        authorIds = request.authorIds!!.map { ID(it) },
+        status = BookPublishStatus.of(request.status!!.value),
+    )
+
+    private fun toResponse(dto: BookDto) = BookResponseModel(
+        id = dto.id.value,
+        title = dto.title,
+        price = dto.price.toLong(),
+        authors = dto.authors.map {
+            AuthorResponseModel(
+                it.id.value,
+                it.name,
+                it.birthDate?.value
+            )
+        },
+        status = BookStatus.of(dto.status.value),
+    )
+}

--- a/presentation/src/test/kotlin/com/bookmanagementsystem/presentation/controller/book/CreateBookControllerTest.kt
+++ b/presentation/src/test/kotlin/com/bookmanagementsystem/presentation/controller/book/CreateBookControllerTest.kt
@@ -1,0 +1,153 @@
+package com.bookmanagementsystem.presentation.controller.book
+
+import com.bookmanagementsystem.presentation.config.IntegrationTestWithSql
+import com.bookmanagementsystem.presentation.model.BadRequestErrorResponseModel
+import com.bookmanagementsystem.presentation.model.BookResponseModel
+import com.bookmanagementsystem.presentation.model.BookStatus
+import com.bookmanagementsystem.presentation.model.CreateBookRequestModel
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.extensions.spring.SpringExtension
+import io.kotest.matchers.shouldBe
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import org.springframework.web.context.WebApplicationContext
+import java.time.LocalDate
+
+/**
+ * CreateBookController の統合テスト。
+ *
+ * 実際に API を通じて書籍登録を行い、バリデーションや正常系の挙動を検証する。
+ * モックではなく実際の環境に近い構成（Spring Boot + MockMvc）で実行される。
+ *
+ * ### 各HTTP ステータスで1パス通せばOK
+ *  context("200") - 正常系：
+ *  context("400") - 異常系：
+ *
+ * 本テストでは、最低限「1パス通ること」で動作確認済みとする。
+ * 異常系・正常系ともに他のテストでカバレッジを確保しており、基本的な入力妥当性を保証する目的。
+ */
+@IntegrationTestWithSql(sqlScript = "CreateBookControllerTest.sql")
+class CreateBookControllerTest : FunSpec() {
+    override fun extensions() = listOf(SpringExtension)
+
+    @Autowired
+    private lateinit var webApplicationContext: WebApplicationContext
+
+    @Autowired
+    private lateinit var objectMapper: ObjectMapper
+    private lateinit var mockMvc: MockMvc
+
+    init {
+        beforeEach {
+            mockMvc = MockMvcBuilders
+                .webAppContextSetup(webApplicationContext)
+                .build()
+        }
+
+        context("200") {
+            test("有効なリクエストで書籍が正常に作成される") {
+                val request = CreateBookRequestModel(
+                    title = "吾輩は猫である",
+                    price = 1500L,
+                    authorIds = listOf(1),
+                    status = BookStatus.PUBLISHED
+                )
+                val requestJson = objectMapper.writeValueAsString(request)
+                val result = mockMvc.perform(
+                    post("/api/books")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestJson)
+                )
+                    .andExpect(status().isOk)
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andReturn()
+
+                // レスポンスボディの検証
+                val responseJson = result.response.contentAsString
+                val response = objectMapper.readValue(responseJson, BookResponseModel::class.java)
+
+                response.id shouldBe 1
+                response.title shouldBe "吾輩は猫である"
+                response.price shouldBe 1500L
+                response.authors?.size shouldBe 1
+                response.authors?.first()?.name shouldBe "夏目漱石"
+                response.authors?.first()?.birthDate shouldBe LocalDate.of(1867, 2, 9)
+                response.status shouldBe BookStatus.PUBLISHED
+            }
+
+            test("複数の著者を持つ書籍が正常に作成される") {
+                val request = CreateBookRequestModel(
+                    title = "日本文学選集",
+                    price = 3000L,
+                    authorIds = listOf(1, 2, 3),
+                    status = BookStatus.PUBLISHED
+                )
+                val requestJson = objectMapper.writeValueAsString(request)
+                val result = mockMvc.perform(
+                    post("/api/books")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestJson)
+                )
+                    .andExpect(status().isOk)
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andReturn()
+
+                // レスポンスボディの検証
+                val responseJson = result.response.contentAsString
+                val response = objectMapper.readValue(responseJson, BookResponseModel::class.java)
+
+                response.title shouldBe "日本文学選集"
+                response.price shouldBe 3000L
+                response.authors?.size shouldBe 3
+
+                // 著者が正しく取得されていることを確認
+                val authorNames = response.authors?.map { it.name } ?: emptyList()
+                authorNames shouldBe listOf("夏目漱石", "太宰治", "芥川龍之介")
+
+                // 各著者の詳細情報も確認
+                response.authors?.get(0)?.id shouldBe 1
+                response.authors?.get(0)?.name shouldBe "夏目漱石"
+                response.authors?.get(0)?.birthDate shouldBe LocalDate.of(1867, 2, 9)
+
+                response.authors?.get(1)?.id shouldBe 2
+                response.authors?.get(1)?.name shouldBe "太宰治"
+                response.authors?.get(1)?.birthDate shouldBe LocalDate.of(1909, 6, 19)
+
+                response.authors?.get(2)?.id shouldBe 3
+                response.authors?.get(2)?.name shouldBe "芥川龍之介"
+                response.authors?.get(2)?.birthDate shouldBe LocalDate.of(1892, 3, 1)
+
+                response.status shouldBe BookStatus.PUBLISHED
+            }
+        }
+
+        context("400") {
+            test("空のJSONの場合バリデーションエラーが発生する") {
+                val requestJson = "{}"
+
+                val result = mockMvc.perform(
+                    post("/api/books")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestJson)
+                )
+                    .andExpect(status().isBadRequest)
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andReturn()
+
+                // BadRequestErrorResponseModel形式のレスポンス検証
+                val responseJson = result.response.contentAsString
+                val errorResponse = objectMapper.readValue(responseJson, BadRequestErrorResponseModel::class.java)
+
+                errorResponse.errors?.isNotEmpty() shouldBe true
+                val errorMessages = errorResponse.errors?.map { it.message } ?: emptyList()
+                errorMessages.any { it?.contains("title") == true } shouldBe true
+            }
+        }
+    }
+}

--- a/presentation/src/test/resources/sql/CreateBookControllerTest.sql
+++ b/presentation/src/test/resources/sql/CreateBookControllerTest.sql
@@ -1,0 +1,20 @@
+-- CreateBookControllerTest用のデータベーステストデータ管理
+
+-- 書籍と著者の関連テーブルをクリーンアップ
+TRUNCATE TABLE book_author CASCADE;
+
+-- 書籍テーブルのデータをクリーンアップ
+TRUNCATE TABLE book CASCADE;
+
+-- 著者テーブルのデータをクリーンアップ  
+TRUNCATE TABLE author CASCADE;
+
+-- テスト用の著者データを挿入
+INSERT INTO author (id, name, birth_date) VALUES
+(1, '夏目漱石', '1867-02-09'),
+(2, '太宰治', '1909-06-19'),
+(3, '芥川龍之介', '1892-03-01');
+
+-- シーケンスをリセット
+ALTER SEQUENCE author_id_seq RESTART WITH 4;
+ALTER SEQUENCE book_id_seq RESTART WITH 1;

--- a/usecase/src/main/kotlin/com/bookmanagementsystem/usecase/author/read/AuthorQueryService.kt
+++ b/usecase/src/main/kotlin/com/bookmanagementsystem/usecase/author/read/AuthorQueryService.kt
@@ -1,0 +1,12 @@
+package com.bookmanagementsystem.usecase.author.read
+
+import com.bookmanagementsystem.domain.book.Book
+import com.bookmanagementsystem.domain.core.ID
+import com.bookmanagementsystem.usecase.author.AuthorDto
+
+interface AuthorQueryService {
+    /**
+     * 書籍に紐づいている著者を取得する
+     */
+    fun findByBookId(bookId: ID<Book>): List<AuthorDto>
+}

--- a/usecase/src/main/kotlin/com/bookmanagementsystem/usecase/book/BookDto.kt
+++ b/usecase/src/main/kotlin/com/bookmanagementsystem/usecase/book/BookDto.kt
@@ -1,0 +1,18 @@
+package com.bookmanagementsystem.usecase.book
+
+import com.bookmanagementsystem.domain.book.Book
+import com.bookmanagementsystem.domain.book.BookPrice
+import com.bookmanagementsystem.domain.book.BookPublishStatus
+import com.bookmanagementsystem.domain.core.ID
+import com.bookmanagementsystem.usecase.author.AuthorDto
+
+/**
+ * 書籍のDTO
+ */
+data class BookDto(
+    val id: ID<Book>,
+    val title: String,
+    val price: BookPrice,
+    val authors: List<AuthorDto>,
+    val status: BookPublishStatus,
+)

--- a/usecase/src/main/kotlin/com/bookmanagementsystem/usecase/book/register/CreateBookCommand.kt
+++ b/usecase/src/main/kotlin/com/bookmanagementsystem/usecase/book/register/CreateBookCommand.kt
@@ -1,0 +1,16 @@
+package com.bookmanagementsystem.usecase.book.register
+
+import com.bookmanagementsystem.domain.author.Author
+import com.bookmanagementsystem.domain.book.BookPrice
+import com.bookmanagementsystem.domain.book.BookPublishStatus
+import com.bookmanagementsystem.domain.core.ID
+
+/**
+ * 書籍を登録するコマンド
+ */
+data class CreateBookCommand(
+    val title: String,
+    val price: BookPrice,
+    val authorIds: List<ID<Author>>,
+    val status: BookPublishStatus,
+)

--- a/usecase/src/main/kotlin/com/bookmanagementsystem/usecase/book/register/CreateBookUsecase.kt
+++ b/usecase/src/main/kotlin/com/bookmanagementsystem/usecase/book/register/CreateBookUsecase.kt
@@ -1,0 +1,39 @@
+package com.bookmanagementsystem.usecase.book.register
+
+import com.bookmanagementsystem.domain.book.Book
+import com.bookmanagementsystem.domain.book.BookRepository
+import com.bookmanagementsystem.usecase.author.AuthorDto
+import com.bookmanagementsystem.usecase.author.read.AuthorQueryService
+import com.bookmanagementsystem.usecase.book.BookDto
+import org.springframework.stereotype.Service
+
+@Service
+class CreateBookUsecase(
+    private val repository: BookRepository,
+    private val authorQueryService: AuthorQueryService,
+) {
+    /**
+     * 書籍を登録する
+     */
+    fun execute(command: CreateBookCommand): BookDto {
+        val book = repository.insert(toEntity(command))
+        val authorDtoList = authorQueryService.findByBookId(book.id!!)
+
+        return toDto(book, authorDtoList)
+    }
+
+    private fun toEntity(command: CreateBookCommand) = Book(
+        title = command.title,
+        price = command.price,
+        authorIds = command.authorIds,
+        status = command.status,
+    )
+
+    private fun toDto(book: Book, authorDtoList: List<AuthorDto>) = BookDto(
+        id = book.id!!,
+        title = book.title,
+        price = book.price,
+        authors = authorDtoList,
+        status = book.status,
+    )
+}

--- a/usecase/src/test/kotlin/com/bookmanagementsystem/usecase/book/register/CreateBookUsecaseTest.kt
+++ b/usecase/src/test/kotlin/com/bookmanagementsystem/usecase/book/register/CreateBookUsecaseTest.kt
@@ -1,0 +1,196 @@
+package com.bookmanagementsystem.usecase.book.register
+
+import com.bookmanagementsystem.domain.author.AuthorBirthDate
+import com.bookmanagementsystem.domain.book.Book
+import com.bookmanagementsystem.domain.book.BookPrice
+import com.bookmanagementsystem.domain.book.BookPublishStatus
+import com.bookmanagementsystem.domain.book.BookRepository
+import com.bookmanagementsystem.domain.core.ID
+import com.bookmanagementsystem.usecase.author.AuthorDto
+import com.bookmanagementsystem.usecase.author.read.AuthorQueryService
+import com.bookmanagementsystem.usecase.book.BookDto
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import java.time.LocalDate
+
+class CreateBookUsecaseTest : FunSpec({
+    test("書籍登録が正常に実行されること") {
+        val repository = mockk<BookRepository>()
+        val authorQueryService = mockk<AuthorQueryService>()
+        val usecase = CreateBookUsecase(repository, authorQueryService)
+
+        val command = CreateBookCommand(
+            title = "テスト書籍",
+            price = BookPrice.of(1000L),
+            authorIds = listOf(ID(1), ID(2)),
+            status = BookPublishStatus.PUBLISHED
+        )
+
+        val savedBook = Book(
+            id = ID(1),
+            title = "テスト書籍",
+            price = BookPrice.of(1000L),
+            authorIds = listOf(ID(1), ID(2)),
+            status = BookPublishStatus.PUBLISHED
+        )
+
+        val authorDtoList = listOf(
+            AuthorDto(
+                id = ID(1),
+                name = "著者1",
+                birthDate = AuthorBirthDate(LocalDate.of(1990, 1, 1))
+            ),
+            AuthorDto(
+                id = ID(2),
+                name = "著者2",
+                birthDate = AuthorBirthDate(LocalDate.of(1985, 5, 15))
+            )
+        )
+
+        every { repository.insert(any()) } returns savedBook
+        every { authorQueryService.findByBookId(ID(1)) } returns authorDtoList
+
+        val result = usecase.execute(command)
+
+        result shouldBe BookDto(
+            id = ID(1),
+            title = "テスト書籍",
+            price = BookPrice.of(1000L),
+            authors = authorDtoList,
+            status = BookPublishStatus.PUBLISHED
+        )
+
+        verify {
+            repository.insert(
+                Book(
+                    title = "テスト書籍",
+                    price = BookPrice.of(1000L),
+                    authorIds = listOf(ID(1), ID(2)),
+                    status = BookPublishStatus.PUBLISHED
+                )
+            )
+        }
+        verify {
+            authorQueryService.findByBookId(ID(1))
+        }
+    }
+
+    test("未出版ステータスの書籍登録が正常に実行されること") {
+        val repository = mockk<BookRepository>()
+        val authorQueryService = mockk<AuthorQueryService>()
+        val usecase = CreateBookUsecase(repository, authorQueryService)
+
+        val command = CreateBookCommand(
+            title = "未出版書籍",
+            price = BookPrice.of(1500L),
+            authorIds = listOf(ID(1)),
+            status = BookPublishStatus.UNPUBLISHED
+        )
+
+        val savedBook = Book(
+            id = ID(2),
+            title = "未出版書籍",
+            price = BookPrice.of(1500L),
+            authorIds = listOf(ID(1)),
+            status = BookPublishStatus.UNPUBLISHED
+        )
+
+        val authorDtoList = listOf(
+            AuthorDto(
+                id = ID(1),
+                name = "著者1",
+                birthDate = null
+            )
+        )
+
+        every { repository.insert(any()) } returns savedBook
+        every { authorQueryService.findByBookId(ID(2)) } returns authorDtoList
+
+        val result = usecase.execute(command)
+
+        result shouldBe BookDto(
+            id = ID(2),
+            title = "未出版書籍",
+            price = BookPrice.of(1500L),
+            authors = authorDtoList,
+            status = BookPublishStatus.UNPUBLISHED
+        )
+
+        verify {
+            repository.insert(
+                Book(
+                    title = "未出版書籍",
+                    price = BookPrice.of(1500L),
+                    authorIds = listOf(ID(1)),
+                    status = BookPublishStatus.UNPUBLISHED
+                )
+            )
+        }
+    }
+
+    test("複数著者の書籍登録が正常に実行されること") {
+        val repository = mockk<BookRepository>()
+        val authorQueryService = mockk<AuthorQueryService>()
+        val usecase = CreateBookUsecase(repository, authorQueryService)
+
+        val command = CreateBookCommand(
+            title = "共著書籍",
+            price = BookPrice.of(2000L),
+            authorIds = listOf(ID(1), ID(2), ID(3)),
+            status = BookPublishStatus.PUBLISHED
+        )
+
+        val savedBook = Book(
+            id = ID(3),
+            title = "共著書籍",
+            price = BookPrice.of(2000L),
+            authorIds = listOf(ID(1), ID(2), ID(3)),
+            status = BookPublishStatus.PUBLISHED
+        )
+
+        val authorDtoList = listOf(
+            AuthorDto(
+                id = ID(1),
+                name = "著者1",
+                birthDate = AuthorBirthDate(LocalDate.of(1980, 3, 10))
+            ),
+            AuthorDto(
+                id = ID(2),
+                name = "著者2",
+                birthDate = AuthorBirthDate(LocalDate.of(1975, 8, 20))
+            ),
+            AuthorDto(
+                id = ID(3),
+                name = "著者3",
+                birthDate = AuthorBirthDate(LocalDate.of(1990, 12, 5))
+            )
+        )
+
+        every { repository.insert(any()) } returns savedBook
+        every { authorQueryService.findByBookId(ID(3)) } returns authorDtoList
+
+        val result = usecase.execute(command)
+
+        result shouldBe BookDto(
+            id = ID(3),
+            title = "共著書籍",
+            price = BookPrice.of(2000L),
+            authors = authorDtoList,
+            status = BookPublishStatus.PUBLISHED
+        )
+
+        verify {
+            repository.insert(
+                Book(
+                    title = "共著書籍",
+                    price = BookPrice.of(2000L),
+                    authorIds = listOf(ID(1), ID(2), ID(3)),
+                    status = BookPublishStatus.PUBLISHED
+                )
+            )
+        }
+    }
+})


### PR DESCRIPTION
## 概要
書籍の登録機能を提供するRESTful APIを実装し、著者との関連付け機能を含む包括的な書籍管理システムを構築

## 詳細
### API仕様
- **エンドポイント**: `POST /api/books`
- **リクエスト**: `CreateBookRequestModel`（タイトル、価格、著者IDリスト、ステータス）
- **レスポンス**: `BookResponseModel`（作成された書籍と著者情報）

### バリデーション
- 書籍価格の範囲制限（0〜9,999,999,999円）
- 著者リストの最小サイズ制約（最低1名）
- 必須フィールドの検証

## 備考
- QueryServiceのテストは別ブランチで対応
  - Repositoryと違って`join`など行っているのでテストは必要と判断