### PR TITLE
refactor: 書籍価格の最大値制約を削除

### DIFF
--- a/presentation/src/main/kotlin/com/bookmanagementsystem/presentation/model/CreateBookRequestModel.kt
+++ b/presentation/src/main/kotlin/com/bookmanagementsystem/presentation/model/CreateBookRequestModel.kt
@@ -22,7 +22,6 @@ data class CreateBookRequestModel(
 
     /* 書籍価格 */
     @get:Min(0L)
-    @get:Max(9999999999L)
     @field:NotNull
     @get:JsonProperty("price") val price: kotlin.Long?,
 

--- a/presentation/src/main/resources/openapi.yml
+++ b/presentation/src/main/resources/openapi.yml
@@ -160,7 +160,6 @@ components:
           type: integer
           format: int64
           minimum: 0
-          maximum: 9999999999
           description: 書籍価格
           example: 1500
         authorIds:

--- a/presentation/src/test/kotlin/com/bookmanagementsystem/presentation/model/CreateBookRequestModelTest.kt
+++ b/presentation/src/test/kotlin/com/bookmanagementsystem/presentation/model/CreateBookRequestModelTest.kt
@@ -64,16 +64,6 @@ class CreateBookRequestModelTest : FunSpec({
         violations.first().messageTemplate shouldBe "{jakarta.validation.constraints.Min.message}"
     }
 
-    test("価格が最大値を超える場合バリデーションエラー") {
-        val requestModel = createValidBookRequest(
-            price = 10000000000L
-        )
-
-        val violations = validator.validate(requestModel)
-        violations shouldHaveSize 1
-        violations.first().messageTemplate shouldBe "{jakarta.validation.constraints.Max.message}"
-    }
-
     test("著者IDリストがnullの場合バリデーションエラー") {
         val requestModel = CreateBookRequestModel(
             title = "人間失格",
@@ -148,16 +138,6 @@ class CreateBookRequestModelTest : FunSpec({
         val requestModel = createValidBookRequest(
             title = "無料本",
             price = 0L
-        )
-
-        val violations = validator.validate(requestModel)
-        violations shouldHaveSize 0
-    }
-
-    test("価格の境界値テスト - 最大値9999999999") {
-        val requestModel = createValidBookRequest(
-            title = "高額本",
-            price = 9999999999L
         )
 
         val violations = validator.validate(requestModel)


### PR DESCRIPTION
## 概要
書籍価格の上限制約（9,999,999,999円）を削除

## 詳細
### 削除された制約
- 書籍価格の上限値：9,999,999,999円
- 関連するバリデーションアノテーション
- OpenAPI仕様での最大値定義

## 備考
- 価格の上限制約を削除することで、0以上という仕様に忠実になる