### PR TITLE
feat: 著者IDに基づく書籍一覧取得APIの実装

### DIFF
--- a/infrastructure/src/main/kotlin/com/bookmanagementsystem/infrastructure/book/BookRecordConverter.kt
+++ b/infrastructure/src/main/kotlin/com/bookmanagementsystem/infrastructure/book/BookRecordConverter.kt
@@ -1,0 +1,42 @@
+package com.bookmanagementsystem.infrastructure.book
+
+import com.bookmanagementsystem.domain.author.AuthorBirthDate
+import com.bookmanagementsystem.domain.book.BookPrice
+import com.bookmanagementsystem.domain.book.BookPublishStatus
+import com.bookmanagementsystem.domain.core.ID
+import com.bookmanagementsystem.jooq.tables.references.BOOK
+import com.bookmanagementsystem.usecase.author.AuthorDto
+import com.bookmanagementsystem.usecase.book.BookDto
+import org.jooq.Record
+
+object BookRecordConverter {
+    /**
+     * 著者情報を含む書籍レコードのリストから、著者DTOのリストを変換する
+     */
+    fun convertAuthorDtoList(records: List<Record>): List<AuthorDto> {
+        return records.map { record ->
+            val authorId = record.get("author_id", Int::class.java)!!
+            val authorName = record.get("author_name", String::class.java)!!
+            val authorBirthDate = record.get("author_birth_date", java.time.LocalDate::class.java)
+
+            AuthorDto(
+                id = ID(authorId),
+                name = authorName,
+                birthDate = authorBirthDate?.let { AuthorBirthDate(it) }
+            )
+        }
+    }
+
+    /**
+     * 書籍レコードと著者DTOのリストから、書籍DTOを変換する
+     */
+    fun convert(bookRecord: Record, authors: List<AuthorDto>): BookDto {
+        return BookDto(
+            id = ID(bookRecord[BOOK.ID]!!),
+            title = bookRecord[BOOK.TITLE]!!,
+            price = BookPrice.of(bookRecord[BOOK.PRICE]!!),
+            authors = authors,
+            status = BookPublishStatus.of(bookRecord[BOOK.PUBLISH_STATUS]!!)
+        )
+    }
+}

--- a/infrastructure/src/test/kotlin/com/bookmanagementsystem/infrastructure/book/BookQueryServiceImplTest.kt
+++ b/infrastructure/src/test/kotlin/com/bookmanagementsystem/infrastructure/book/BookQueryServiceImplTest.kt
@@ -1,0 +1,162 @@
+package com.bookmanagementsystem.infrastructure.book
+
+import com.bookmanagementsystem.domain.author.Author
+import com.bookmanagementsystem.domain.author.AuthorBirthDate
+import com.bookmanagementsystem.domain.book.BookPrice
+import com.bookmanagementsystem.domain.book.BookPublishStatus
+import com.bookmanagementsystem.domain.core.ID
+import com.bookmanagementsystem.infrastructure.config.IntegrationTestWithSql
+import com.bookmanagementsystem.usecase.book.read.BookQueryService
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.extensions.spring.SpringExtension
+import io.kotest.matchers.shouldBe
+import java.math.BigDecimal
+import java.time.LocalDate
+
+/**
+ * BookQueryServiceImpl の統合テスト。
+ *
+ * 実際にデータベースに対してクエリを実行し、著者IDに紐づく書籍一覧の取得機能を検証する。
+ * モックではなく実際の環境に近い構成（Spring Boot + PostgreSQL）で実行される。
+ *
+ * インフラストラクチャ層として、データベースからの正確なデータ取得を保証する目的。
+ */
+@IntegrationTestWithSql(sqlScript = "BookQueryServiceImplTest.sql")
+class BookQueryServiceImplTest(private val bookQueryService: BookQueryService) : FunSpec() {
+    override fun extensions() = listOf(SpringExtension)
+
+    init {
+        context("正常系") {
+            test("著者IDに紐づく書籍が正常に取得される") {
+                val authorId = ID<Author>(1)
+
+                val books = bookQueryService.findByAuthorId(authorId)
+
+                books.size shouldBe 2
+
+                // 書籍IDでソート済みであることを前提に検証
+                val book1 = books[0]
+                book1.id.value shouldBe 1
+                book1.title shouldBe "吾輩は猫である"
+                book1.price shouldBe BookPrice.of(BigDecimal("1500.00"))
+                book1.status shouldBe BookPublishStatus.PUBLISHED
+                book1.authors.size shouldBe 1
+                book1.authors[0].id.value shouldBe 1
+                book1.authors[0].name shouldBe "夏目漱石"
+                book1.authors[0].birthDate shouldBe AuthorBirthDate(LocalDate.of(1867, 2, 9))
+
+                val book2 = books[1]
+                book2.id.value shouldBe 2
+                book2.title shouldBe "日本文学選集"
+                book2.price shouldBe BookPrice.of(BigDecimal("3000.00"))
+                book2.status shouldBe BookPublishStatus.PUBLISHED
+                book2.authors.size shouldBe 3
+            }
+
+            test("著者IDに紐づく複数の書籍が正常に取得される") {
+                val authorId = ID<Author>(2)
+
+                val books = bookQueryService.findByAuthorId(authorId)
+
+                books.size shouldBe 2
+
+                // 書籍IDでソート済みであることを前提に検証
+                val book1 = books[0]
+                book1.id.value shouldBe 2
+                book1.title shouldBe "日本文学選集"
+                book1.price shouldBe BookPrice.of(BigDecimal("3000.00"))
+                book1.status shouldBe BookPublishStatus.PUBLISHED
+                book1.authors.size shouldBe 3
+
+                val book2 = books[1]
+                book2.id.value shouldBe 4
+                book2.title shouldBe "文学論"
+                book2.price shouldBe BookPrice.of(BigDecimal("2500.00"))
+                book2.status shouldBe BookPublishStatus.PUBLISHED
+                book2.authors.size shouldBe 1
+                book2.authors[0].id.value shouldBe 2
+                book2.authors[0].name shouldBe "太宰治"
+                book2.authors[0].birthDate shouldBe AuthorBirthDate(LocalDate.of(1909, 6, 19))
+            }
+
+            test("共著書籍の場合、すべての著者情報が正常に取得される") {
+                val authorId = ID<Author>(1)
+
+                val books = bookQueryService.findByAuthorId(authorId)
+                val collaborativeBook = books.find { it.id.value == 2 }
+
+                collaborativeBook!!.authors.size shouldBe 3
+
+                // 著者IDでソートされていることを前提に検証
+                collaborativeBook.authors[0].id.value shouldBe 1
+                collaborativeBook.authors[0].name shouldBe "夏目漱石"
+                collaborativeBook.authors[0].birthDate shouldBe AuthorBirthDate(LocalDate.of(1867, 2, 9))
+
+                collaborativeBook.authors[1].id.value shouldBe 2
+                collaborativeBook.authors[1].name shouldBe "太宰治"
+                collaborativeBook.authors[1].birthDate shouldBe AuthorBirthDate(LocalDate.of(1909, 6, 19))
+
+                collaborativeBook.authors[2].id.value shouldBe 3
+                collaborativeBook.authors[2].name shouldBe "芥川龍之介"
+                collaborativeBook.authors[2].birthDate shouldBe AuthorBirthDate(LocalDate.of(1892, 3, 1))
+            }
+
+            test("著者IDに紐づく単一の書籍が正常に取得される") {
+                val authorId = ID<Author>(3)
+
+                val books = bookQueryService.findByAuthorId(authorId)
+
+                books.size shouldBe 2
+
+                // 書籍IDでソート済みであることを前提に検証（共著書籍と単独著作）
+                val collaborativeBook = books[0]
+                collaborativeBook.id.value shouldBe 2
+                collaborativeBook.title shouldBe "日本文学選集"
+                collaborativeBook.authors.size shouldBe 3
+
+                val singleAuthorBook = books[1]
+                singleAuthorBook.id.value shouldBe 5
+                singleAuthorBook.title shouldBe "こころ"
+                singleAuthorBook.price shouldBe BookPrice.of(BigDecimal("1800.00"))
+                singleAuthorBook.status shouldBe BookPublishStatus.PUBLISHED
+                singleAuthorBook.authors.size shouldBe 1
+                singleAuthorBook.authors[0].id.value shouldBe 3
+                singleAuthorBook.authors[0].name shouldBe "芥川龍之介"
+                singleAuthorBook.authors[0].birthDate shouldBe AuthorBirthDate(LocalDate.of(1892, 3, 1))
+            }
+
+            test("生年月日がnullの著者を持つ書籍が正常に取得される") {
+                val authorId = ID<Author>(4)
+
+                val books = bookQueryService.findByAuthorId(authorId)
+
+                books.size shouldBe 1
+                val book = books[0]
+                book.id.value shouldBe 3
+                book.title shouldBe "謎の小説"
+                book.price shouldBe BookPrice.of(BigDecimal("2000.00"))
+                book.status shouldBe BookPublishStatus.PUBLISHED
+                book.authors.size shouldBe 1
+                book.authors[0].id.value shouldBe 4
+                book.authors[0].name shouldBe "匿名作家"
+                book.authors[0].birthDate shouldBe null
+            }
+
+            test("存在しない著者IDの場合は空のリストが返される") {
+                val authorId = ID<Author>(999)
+
+                val books = bookQueryService.findByAuthorId(authorId)
+
+                books shouldBe emptyList()
+            }
+
+            test("書籍を持たない著者IDの場合は空のリストが返される") {
+                val authorId = ID<Author>(5)
+
+                val books = bookQueryService.findByAuthorId(authorId)
+
+                books shouldBe emptyList()
+            }
+        }
+    }
+}

--- a/infrastructure/src/test/resources/sql/BookQueryServiceImplTest.sql
+++ b/infrastructure/src/test/resources/sql/BookQueryServiceImplTest.sql
@@ -1,0 +1,49 @@
+-- BookQueryServiceImplTest用のデータベーステストデータ管理
+
+-- 書籍と著者の関連テーブルをクリーンアップ
+TRUNCATE TABLE book_author CASCADE;
+
+-- 書籍テーブルのデータをクリーンアップ
+TRUNCATE TABLE book CASCADE;
+
+-- 著者テーブルのデータをクリーンアップ  
+TRUNCATE TABLE author CASCADE;
+
+-- テスト用の著者データを挿入
+INSERT INTO author (id, name, birth_date) VALUES
+(1, '夏目漱石', '1867-02-09'),
+(2, '太宰治', '1909-06-19'),
+(3, '芥川龍之介', '1892-03-01'),
+(4, '匿名作家', NULL),
+(5, '書籍なし著者', '1900-01-01');
+
+-- テスト用の書籍データを挿入
+INSERT INTO book (id, title, price, publish_status) VALUES
+(1, '吾輩は猫である', 1500.00, 2),
+(2, '日本文学選集', 3000.00, 2),
+(3, '謎の小説', 2000.00, 2),
+(4, '文学論', 2500.00, 2),
+(5, 'こころ', 1800.00, 2);
+
+-- 書籍と著者の関連データを挿入
+-- 書籍1: 夏目漱石のみ
+INSERT INTO book_author (book_id, author_id) VALUES (1, 1);
+
+-- 書籍2: 夏目漱石、太宰治、芥川龍之介（複数著者の共著）
+INSERT INTO book_author (book_id, author_id) VALUES 
+(2, 1),
+(2, 2),
+(2, 3);
+
+-- 書籍3: 匿名作家（birth_dateがnull）
+INSERT INTO book_author (book_id, author_id) VALUES (3, 4);
+
+-- 書籍4: 太宰治のみ（太宰治の2冊目）
+INSERT INTO book_author (book_id, author_id) VALUES (4, 2);
+
+-- 書籍5: 芥川龍之介のみ（単独著作のテストケース用）
+INSERT INTO book_author (book_id, author_id) VALUES (5, 3);
+
+-- シーケンスをリセット
+ALTER SEQUENCE author_id_seq RESTART WITH 6;
+ALTER SEQUENCE book_id_seq RESTART WITH 6;

--- a/presentation/src/main/kotlin/com/bookmanagementsystem/presentation/controller/author/ReadAuthorBookController.kt
+++ b/presentation/src/main/kotlin/com/bookmanagementsystem/presentation/controller/author/ReadAuthorBookController.kt
@@ -1,0 +1,38 @@
+package com.bookmanagementsystem.presentation.controller.author
+
+import com.bookmanagementsystem.domain.core.ID
+import com.bookmanagementsystem.presentation.model.AuthorResponseModel
+import com.bookmanagementsystem.presentation.model.BookResponseModel
+import com.bookmanagementsystem.presentation.model.BookStatus
+import com.bookmanagementsystem.usecase.author.read.ReadAuthorBookUsecase
+import com.bookmanagementsystem.usecase.book.BookDto
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class ReadAuthorBookController(private val usecase: ReadAuthorBookUsecase) {
+    /**
+     * 著者に紐づく書籍一覧を取得する
+     */
+    @GetMapping("/api/authors/{id}/books")
+    fun read(@PathVariable id: Int): List<BookResponseModel> {
+        val bookDtoList = usecase.execute(ID(id))
+
+        return bookDtoList.map { toResponse(it) }
+    }
+
+    private fun toResponse(dto: BookDto) = BookResponseModel(
+        id = dto.id.value,
+        title = dto.title,
+        price = dto.price.toLong(),
+        authors = dto.authors.map {
+            AuthorResponseModel(
+                id = it.id.value,
+                name = it.name,
+                birthDate = it.birthDate?.value
+            )
+        },
+        status = BookStatus.of(dto.status.value)
+    )
+}

--- a/presentation/src/main/resources/openapi.yml
+++ b/presentation/src/main/resources/openapi.yml
@@ -98,7 +98,9 @@ paths:
             format: int32
       responses:
         '200':
-          description: 書籍一覧の取得に成功
+          description: |
+            - 書籍一覧の取得に成功
+            - 書籍が見つからない場合は空配列を返す
           content:
             application/json:
               schema:
@@ -106,7 +108,7 @@ paths:
                 items:
                   $ref: '#/components/schemas/BookResponseModel'
         '404':
-          description: 著者 または 書籍 が存在しない場合
+          description: 著者が存在しない場合
           content:
             application/json:
               schema:

--- a/presentation/src/test/kotlin/com/bookmanagementsystem/presentation/controller/author/ReadAuthorBookControllerTest.kt
+++ b/presentation/src/test/kotlin/com/bookmanagementsystem/presentation/controller/author/ReadAuthorBookControllerTest.kt
@@ -1,0 +1,155 @@
+package com.bookmanagementsystem.presentation.controller.author
+
+import com.bookmanagementsystem.presentation.config.IntegrationTestWithSql
+import com.bookmanagementsystem.presentation.model.BookResponseModel
+import com.bookmanagementsystem.presentation.model.BookStatus
+import com.bookmanagementsystem.presentation.model.NotFoundErrorResponseModel
+import com.fasterxml.jackson.core.type.TypeReference
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.extensions.spring.SpringExtension
+import io.kotest.matchers.shouldBe
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import org.springframework.web.context.WebApplicationContext
+import java.time.LocalDate
+
+/**
+ * ReadAuthorBookController の統合テスト。
+ *
+ * 実際に API を通じて著者に紐づく書籍一覧の取得を行い、正常系・異常系の挙動を検証する。
+ * モックではなく実際の環境に近い構成（Spring Boot + MockMvc）で実行される。
+ *
+ * ### 各HTTP ステータスで1パス通せばOK
+ *  context("200") - 正常系：
+ *  context("404") - 異常系：
+ *
+ * 本テストでは、最低限「1パス通ること」で動作確認済みとする。
+ * 異常系・正常系ともに他のテストでカバレッジを確保しており、基本的な入力妥当性を保証する目的。
+ */
+@IntegrationTestWithSql(sqlScript = "ReadAuthorBookControllerTest.sql")
+class ReadAuthorBookControllerTest : FunSpec() {
+    override fun extensions() = listOf(SpringExtension)
+
+    @Autowired
+    private lateinit var webApplicationContext: WebApplicationContext
+
+    @Autowired
+    private lateinit var objectMapper: ObjectMapper
+    private lateinit var mockMvc: MockMvc
+
+    init {
+        beforeEach {
+            mockMvc = MockMvcBuilders
+                .webAppContextSetup(webApplicationContext)
+                .build()
+        }
+
+        context("200") {
+            test("著者IDに紐づく書籍一覧が正常に取得される") {
+                val result = mockMvc.perform(
+                    get("/api/authors/1/books")
+                        .contentType(MediaType.APPLICATION_JSON)
+                )
+                    .andExpect(status().isOk)
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andReturn()
+
+                // レスポンスボディの検証
+                val responseJson = result.response.contentAsString
+                val response = objectMapper.readValue(
+                    responseJson,
+                    object : TypeReference<List<BookResponseModel>>() {}
+                )
+
+                response.size shouldBe 2
+
+                // 1冊目の書籍検証
+                val book1 = response[0]
+                book1.id shouldBe 1
+                book1.title shouldBe "吾輩は猫である"
+                book1.price shouldBe 1500L
+                book1.status shouldBe BookStatus.PUBLISHED
+                book1.authors?.size shouldBe 1
+                book1.authors?.get(0)?.id shouldBe 1
+                book1.authors?.get(0)?.name shouldBe "夏目漱石"
+                book1.authors?.get(0)?.birthDate shouldBe LocalDate.of(1867, 2, 9)
+
+                // 2冊目の書籍検証（共著）
+                val book2 = response[1]
+                book2.id shouldBe 2
+                book2.title shouldBe "日本文学選集"
+                book2.price shouldBe 3000L
+                book2.status shouldBe BookStatus.PUBLISHED
+                book2.authors?.size shouldBe 3
+            }
+
+            test("著者に紐づく書籍が存在しない場合、空の配列が返される") {
+                val result = mockMvc.perform(
+                    get("/api/authors/5/books")
+                        .contentType(MediaType.APPLICATION_JSON)
+                )
+                    .andExpect(status().isOk)
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andReturn()
+
+                // レスポンスボディの検証
+                val responseJson = result.response.contentAsString
+                val response =
+                    objectMapper.readValue(responseJson, object : TypeReference<List<BookResponseModel>>() {})
+
+                response.size shouldBe 0
+            }
+
+            test("単独著作の書籍が正常に取得される") {
+                val result = mockMvc.perform(
+                    get("/api/authors/2/books")
+                        .contentType(MediaType.APPLICATION_JSON)
+                )
+                    .andExpect(status().isOk)
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andReturn()
+
+                // レスポンスボディの検証
+                val responseJson = result.response.contentAsString
+                val response =
+                    objectMapper.readValue(responseJson, object : TypeReference<List<BookResponseModel>>() {})
+
+                response.size shouldBe 2
+
+                // 単独著作の書籍検証
+                val singleAuthorBook = response.find { it.id == 4 }
+                singleAuthorBook!!.title shouldBe "文学論"
+                singleAuthorBook.price shouldBe 2500L
+                singleAuthorBook.authors?.size shouldBe 1
+                singleAuthorBook.authors?.get(0)?.id shouldBe 2
+                singleAuthorBook.authors?.get(0)?.name shouldBe "太宰治"
+            }
+        }
+
+        context("404") {
+            test("存在しない著者IDの場合、404エラーが発生する") {
+                val result = mockMvc.perform(
+                    get("/api/authors/999/books")
+                        .contentType(MediaType.APPLICATION_JSON)
+                )
+                    .andExpect(status().isNotFound)
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andReturn()
+
+                // エラーレスポンスボディの検証
+                val responseJson = result.response.contentAsString
+                val errorResponse = objectMapper.readValue(responseJson, NotFoundErrorResponseModel::class.java)
+
+                errorResponse.errors?.size shouldBe 1
+                errorResponse.errors?.first()?.code shouldBe "NOT_FOUND"
+                errorResponse.errors?.first()?.message shouldBe "著者が見つかりません。ID: 999"
+            }
+        }
+    }
+}

--- a/presentation/src/test/resources/sql/ReadAuthorBookControllerTest.sql
+++ b/presentation/src/test/resources/sql/ReadAuthorBookControllerTest.sql
@@ -1,0 +1,45 @@
+-- ReadAuthorBookControllerTest用のデータベーステストデータ管理
+
+-- 書籍と著者の関連テーブルをクリーンアップ
+TRUNCATE TABLE book_author CASCADE;
+
+-- 書籍テーブルのデータをクリーンアップ
+TRUNCATE TABLE book CASCADE;
+
+-- 著者テーブルのデータをクリーンアップ  
+TRUNCATE TABLE author CASCADE;
+
+-- テスト用の著者データを挿入
+INSERT INTO author (id, name, birth_date) VALUES
+(1, '夏目漱石', '1867-02-09'),
+(2, '太宰治', '1909-06-19'),
+(3, '芥川龍之介', '1892-03-01'),
+(4, '匿名作家', NULL),
+(5, '書籍なし著者', '1900-01-01');
+
+-- テスト用の書籍データを挿入
+INSERT INTO book (id, title, price, publish_status) VALUES
+(1, '吾輩は猫である', 1500.00, 2),
+(2, '日本文学選集', 3000.00, 2),
+(3, '謎の小説', 2000.00, 2),
+(4, '文学論', 2500.00, 2);
+
+-- 書籍と著者の関連データを挿入
+-- 書籍1: 夏目漱石のみ
+INSERT INTO book_author (book_id, author_id) VALUES (1, 1);
+
+-- 書籍2: 夏目漱石、太宰治、芥川龍之介（複数著者の共著）
+INSERT INTO book_author (book_id, author_id) VALUES 
+(2, 1),
+(2, 2),
+(2, 3);
+
+-- 書籍3: 匿名作家（birth_dateがnull）
+INSERT INTO book_author (book_id, author_id) VALUES (3, 4);
+
+-- 書籍4: 太宰治のみ（太宰治の2冊目）
+INSERT INTO book_author (book_id, author_id) VALUES (4, 2);
+
+-- シーケンスをリセット
+ALTER SEQUENCE author_id_seq RESTART WITH 6;
+ALTER SEQUENCE book_id_seq RESTART WITH 5;

--- a/usecase/src/main/kotlin/com/bookmanagementsystem/usecase/author/read/ReadAuthorBookUsecase.kt
+++ b/usecase/src/main/kotlin/com/bookmanagementsystem/usecase/author/read/ReadAuthorBookUsecase.kt
@@ -1,0 +1,24 @@
+package com.bookmanagementsystem.usecase.author.read
+
+import com.bookmanagementsystem.domain.author.Author
+import com.bookmanagementsystem.domain.author.AuthorRepository
+import com.bookmanagementsystem.domain.core.ID
+import com.bookmanagementsystem.usecase.book.BookDto
+import com.bookmanagementsystem.usecase.book.read.BookQueryService
+import org.springframework.stereotype.Service
+
+@Service
+class ReadAuthorBookUsecase(
+    private val authorRepository: AuthorRepository,
+    private val bookQueryService: BookQueryService
+) {
+    /**
+     * 指定された著者IDに紐づく書籍一覧を取得する
+     */
+    fun execute(authorId: ID<Author>): List<BookDto> {
+        authorRepository.findById(authorId)
+            ?: throw NoSuchElementException("著者が見つかりません。ID: ${authorId.value}")
+
+        return bookQueryService.findByAuthorId(authorId)
+    }
+}

--- a/usecase/src/main/kotlin/com/bookmanagementsystem/usecase/book/read/BookQueryService.kt
+++ b/usecase/src/main/kotlin/com/bookmanagementsystem/usecase/book/read/BookQueryService.kt
@@ -1,0 +1,12 @@
+package com.bookmanagementsystem.usecase.book.read
+
+import com.bookmanagementsystem.domain.author.Author
+import com.bookmanagementsystem.domain.core.ID
+import com.bookmanagementsystem.usecase.book.BookDto
+
+interface BookQueryService {
+    /**
+     * 著者IDに紐づく書籍一覧を取得する
+     */
+    fun findByAuthorId(authorId: ID<Author>): List<BookDto>
+}

--- a/usecase/src/test/kotlin/com/bookmanagementsystem/usecase/author/read/ReadAuthorBookUsecaseTest.kt
+++ b/usecase/src/test/kotlin/com/bookmanagementsystem/usecase/author/read/ReadAuthorBookUsecaseTest.kt
@@ -1,0 +1,155 @@
+package com.bookmanagementsystem.usecase.author.read
+
+import com.bookmanagementsystem.domain.author.Author
+import com.bookmanagementsystem.domain.author.AuthorBirthDate
+import com.bookmanagementsystem.domain.author.AuthorRepository
+import com.bookmanagementsystem.domain.book.BookPrice
+import com.bookmanagementsystem.domain.book.BookPublishStatus
+import com.bookmanagementsystem.domain.core.ID
+import com.bookmanagementsystem.usecase.author.AuthorDto
+import com.bookmanagementsystem.usecase.book.BookDto
+import com.bookmanagementsystem.usecase.book.read.BookQueryService
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import java.math.BigDecimal
+import java.time.LocalDate
+
+class ReadAuthorBookUsecaseTest : FunSpec({
+    test("著者IDに紐づく書籍一覧が正常に取得されること") {
+        val authorRepository = mockk<AuthorRepository>()
+        val bookQueryService = mockk<BookQueryService>()
+        val usecase = ReadAuthorBookUsecase(authorRepository, bookQueryService)
+        val authorId = ID<Author>(1)
+        val author = Author(
+            id = authorId,
+            name = "夏目漱石",
+            birthDate = AuthorBirthDate(LocalDate.of(1867, 2, 9))
+        )
+        val expectedBooks = listOf(
+            BookDto(
+                id = ID(1),
+                title = "吾輩は猫である",
+                price = BookPrice.of(BigDecimal("1500.00")),
+                authors = listOf(
+                    AuthorDto(
+                        id = ID(1),
+                        name = "夏目漱石",
+                        birthDate = AuthorBirthDate(LocalDate.of(1867, 2, 9))
+                    )
+                ),
+                status = BookPublishStatus.PUBLISHED
+            ),
+            BookDto(
+                id = ID(2),
+                title = "こころ",
+                price = BookPrice.of(BigDecimal("1800.00")),
+                authors = listOf(
+                    AuthorDto(
+                        id = ID(1),
+                        name = "夏目漱石",
+                        birthDate = AuthorBirthDate(LocalDate.of(1867, 2, 9))
+                    )
+                ),
+                status = BookPublishStatus.PUBLISHED
+            )
+        )
+
+        every { authorRepository.findById(authorId) } returns author
+        every { bookQueryService.findByAuthorId(authorId) } returns expectedBooks
+
+        val result = usecase.execute(authorId)
+
+        result shouldBe expectedBooks
+        verify { authorRepository.findById(authorId) }
+        verify { bookQueryService.findByAuthorId(authorId) }
+    }
+
+    test("著者に紐づく書籍が存在しない場合、空のリストが返されること") {
+        val authorRepository = mockk<AuthorRepository>()
+        val bookQueryService = mockk<BookQueryService>()
+        val usecase = ReadAuthorBookUsecase(authorRepository, bookQueryService)
+        val authorId = ID<Author>(999)
+        val author = Author(
+            id = authorId,
+            name = "書籍なし著者",
+            birthDate = AuthorBirthDate(LocalDate.of(1900, 1, 1))
+        )
+
+        every { authorRepository.findById(authorId) } returns author
+        every { bookQueryService.findByAuthorId(authorId) } returns emptyList()
+
+        val result = usecase.execute(authorId)
+
+        result shouldBe emptyList()
+        verify { authorRepository.findById(authorId) }
+        verify { bookQueryService.findByAuthorId(authorId) }
+    }
+
+    test("存在しない著者IDの場合、NoSuchElementExceptionが発生すること") {
+        val authorRepository = mockk<AuthorRepository>()
+        val bookQueryService = mockk<BookQueryService>()
+        val usecase = ReadAuthorBookUsecase(authorRepository, bookQueryService)
+        val authorId = ID<Author>(999)
+
+        every { authorRepository.findById(authorId) } returns null
+
+        val exception = shouldThrow<NoSuchElementException> {
+            usecase.execute(authorId)
+        }
+
+        exception.message shouldBe "著者が見つかりません。ID: 999"
+        verify { authorRepository.findById(authorId) }
+        verify(exactly = 0) { bookQueryService.findByAuthorId(any()) }
+    }
+
+    test("複数の著者による共著書籍が含まれる場合も正常に取得されること") {
+        val authorRepository = mockk<AuthorRepository>()
+        val bookQueryService = mockk<BookQueryService>()
+        val usecase = ReadAuthorBookUsecase(authorRepository, bookQueryService)
+        val authorId = ID<Author>(1)
+        val author = Author(
+            id = authorId,
+            name = "夏目漱石",
+            birthDate = AuthorBirthDate(LocalDate.of(1867, 2, 9))
+        )
+        val expectedBooks = listOf(
+            BookDto(
+                id = ID(1),
+                title = "日本文学選集",
+                price = BookPrice.of(BigDecimal("3000.00")),
+                authors = listOf(
+                    AuthorDto(
+                        id = ID(1),
+                        name = "夏目漱石",
+                        birthDate = AuthorBirthDate(LocalDate.of(1867, 2, 9))
+                    ),
+                    AuthorDto(
+                        id = ID(2),
+                        name = "太宰治",
+                        birthDate = AuthorBirthDate(LocalDate.of(1909, 6, 19))
+                    ),
+                    AuthorDto(
+                        id = ID(3),
+                        name = "芥川龍之介",
+                        birthDate = AuthorBirthDate(LocalDate.of(1892, 3, 1))
+                    )
+                ),
+                status = BookPublishStatus.PUBLISHED
+            )
+        )
+
+        every { authorRepository.findById(authorId) } returns author
+        every { bookQueryService.findByAuthorId(authorId) } returns expectedBooks
+
+        val result = usecase.execute(authorId)
+
+        result shouldBe expectedBooks
+        result[0].authors.size shouldBe 3
+        verify { authorRepository.findById(authorId) }
+        verify { bookQueryService.findByAuthorId(authorId) }
+    }
+})


### PR DESCRIPTION
## 概要
著者IDに紐づく書籍一覧を取得するAPIを実装

## 詳細

### 新機能
| 機能 | 説明 |
| --- | --- |
| `ReadAuthorBookController` | 著者IDに基づく書籍一覧取得用のRESTコントローラー |
| `ReadAuthorBookUsecase` | 書籍一覧取得のビジネスロジック |
| `BookQueryService` | 著者IDに基づく書籍検索機能 |
| `BookRecordConverter` | 書籍レコード変換の共通処理 |

### API仕様
- **エンドポイント**: `GET /api/authors/{id}/books`
- **パラメータ**: `id` (path) - 著者ID
- **レスポンス**: `BookResponseModel[]` - 書籍一覧
- **エラー**: 404（著者が存在しない場合）

## 備考
- [x] テスト実施