### PR TITLE
fix: 各テーブルのversionをnot nullに変更

### DIFF
--- a/infrastructure/src/main/jooq/com/bookmanagementsystem/jooq/tables/Author.kt
+++ b/infrastructure/src/main/jooq/com/bookmanagementsystem/jooq/tables/Author.kt
@@ -94,7 +94,7 @@ open class Author(
     /**
      * The column <code>public.author.version</code>. バージョン（楽観的ロック用）
      */
-    val VERSION: TableField<AuthorRecord, Int?> = createField(DSL.name("version"), SQLDataType.INTEGER, this, "バージョン（楽観的ロック用）")
+    val VERSION: TableField<AuthorRecord, Int?> = createField(DSL.name("version"), SQLDataType.INTEGER.nullable(false), this, "バージョン（楽観的ロック用）")
 
     private constructor(alias: Name, aliased: Table<AuthorRecord>?): this(alias, null, null, null, aliased, null, null)
     private constructor(alias: Name, aliased: Table<AuthorRecord>?, parameters: Array<Field<*>?>?): this(alias, null, null, null, aliased, parameters, null)

--- a/infrastructure/src/main/jooq/com/bookmanagementsystem/jooq/tables/Book.kt
+++ b/infrastructure/src/main/jooq/com/bookmanagementsystem/jooq/tables/Book.kt
@@ -99,7 +99,7 @@ open class Book(
     /**
      * The column <code>public.book.version</code>. バージョン（楽観的ロック用）
      */
-    val VERSION: TableField<BookRecord, Int?> = createField(DSL.name("version"), SQLDataType.INTEGER, this, "バージョン（楽観的ロック用）")
+    val VERSION: TableField<BookRecord, Int?> = createField(DSL.name("version"), SQLDataType.INTEGER.nullable(false), this, "バージョン（楽観的ロック用）")
 
     private constructor(alias: Name, aliased: Table<BookRecord>?): this(alias, null, null, null, aliased, null, null)
     private constructor(alias: Name, aliased: Table<BookRecord>?, parameters: Array<Field<*>?>?): this(alias, null, null, null, aliased, parameters, null)

--- a/infrastructure/src/main/jooq/com/bookmanagementsystem/jooq/tables/BookAuthor.kt
+++ b/infrastructure/src/main/jooq/com/bookmanagementsystem/jooq/tables/BookAuthor.kt
@@ -88,7 +88,7 @@ open class BookAuthor(
     /**
      * The column <code>public.book_author.version</code>. バージョン（楽観的ロック用）
      */
-    val VERSION: TableField<BookAuthorRecord, Int?> = createField(DSL.name("version"), SQLDataType.INTEGER, this, "バージョン（楽観的ロック用）")
+    val VERSION: TableField<BookAuthorRecord, Int?> = createField(DSL.name("version"), SQLDataType.INTEGER.nullable(false), this, "バージョン（楽観的ロック用）")
 
     private constructor(alias: Name, aliased: Table<BookAuthorRecord>?): this(alias, null, null, null, aliased, null, null)
     private constructor(alias: Name, aliased: Table<BookAuthorRecord>?, parameters: Array<Field<*>?>?): this(alias, null, null, null, aliased, parameters, null)

--- a/infrastructure/src/main/resources/db/migration/V1__create_book_table.sql
+++ b/infrastructure/src/main/resources/db/migration/V1__create_book_table.sql
@@ -4,7 +4,7 @@ CREATE TABLE IF NOT EXISTS book (
     title          VARCHAR(255) NOT NULL,
     price          NUMERIC(10, 2) NOT NULL,
     publish_status INTEGER NOT NULL,
-    version        INTEGER
+    version        INTEGER NOT NULL
 );
 
 -- テーブルとカラムにコメントを追加

--- a/infrastructure/src/main/resources/db/migration/V2__create_author_table.sql
+++ b/infrastructure/src/main/resources/db/migration/V2__create_author_table.sql
@@ -3,7 +3,7 @@ CREATE TABLE IF NOT EXISTS author (
     id          SERIAL PRIMARY KEY,
     name        VARCHAR(100) NOT NULL,
     birth_date  DATE,
-    version     INTEGER
+    version     INTEGER NOT NULL
 );
 
 -- テーブルとカラムにコメントを追加

--- a/infrastructure/src/main/resources/db/migration/V3__create_book_author_table.sql
+++ b/infrastructure/src/main/resources/db/migration/V3__create_book_author_table.sql
@@ -2,7 +2,7 @@
 CREATE TABLE book_author (
     book_id   INTEGER NOT NULL REFERENCES book(id),
     author_id INTEGER NOT NULL REFERENCES author (id),
-    version   INTEGER,
+    version   INTEGER NOT NULL,
     PRIMARY KEY (book_id, author_id)
 );
 


### PR DESCRIPTION
修正漏れ対応
version追加時に`not null`制約をつけていなかった