### PR TITLE
refactor: 著者リポジトリに楽観的ロック機能を実装

### DIFF
--- a/presentation/src/main/kotlin/com/bookmanagementsystem/presentation/handler/GlobalExceptionHandler.kt
+++ b/presentation/src/main/kotlin/com/bookmanagementsystem/presentation/handler/GlobalExceptionHandler.kt
@@ -3,6 +3,8 @@ package com.bookmanagementsystem.presentation.handler
 import com.bookmanagementsystem.presentation.model.BadRequestErrorResponseModel
 import com.bookmanagementsystem.presentation.model.ErrorModel
 import com.bookmanagementsystem.presentation.model.NotFoundErrorResponseModel
+import com.bookmanagementsystem.presentation.model.OptimisticLockErrorResponseModel
+import com.bookmanagementsystem.infrastructure.exception.OptimisticLockException
 import com.bookmanagementsystem.usecase.exception.UsecaseViolationException
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -47,6 +49,18 @@ class GlobalExceptionHandler {
             errors = listOf(errorModel)
         )
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(error)
+    }
+
+    @ExceptionHandler(OptimisticLockException::class)
+    fun handleOptimisticLockException(ex: OptimisticLockException): ResponseEntity<OptimisticLockErrorResponseModel> {
+        val errorModel = ErrorModel(
+            code = "OPTIMISTIC_LOCK_EXCEPTION",
+            message = ex.message ?: "楽観的ロックエラーが発生しました"
+        )
+        val error = OptimisticLockErrorResponseModel(
+            errors = listOf(errorModel)
+        )
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(error)
     }
 
     @ExceptionHandler(IllegalArgumentException::class)

--- a/presentation/src/main/kotlin/com/bookmanagementsystem/presentation/handler/GlobalExceptionHandler.kt
+++ b/presentation/src/main/kotlin/com/bookmanagementsystem/presentation/handler/GlobalExceptionHandler.kt
@@ -1,10 +1,10 @@
 package com.bookmanagementsystem.presentation.handler
 
+import com.bookmanagementsystem.infrastructure.exception.OptimisticLockException
 import com.bookmanagementsystem.presentation.model.BadRequestErrorResponseModel
 import com.bookmanagementsystem.presentation.model.ErrorModel
 import com.bookmanagementsystem.presentation.model.NotFoundErrorResponseModel
 import com.bookmanagementsystem.presentation.model.OptimisticLockErrorResponseModel
-import com.bookmanagementsystem.infrastructure.exception.OptimisticLockException
 import com.bookmanagementsystem.usecase.exception.UsecaseViolationException
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity

--- a/presentation/src/test/kotlin/com/bookmanagementsystem/presentation/controller/author/UpdateAuthorControllerTest.kt
+++ b/presentation/src/test/kotlin/com/bookmanagementsystem/presentation/controller/author/UpdateAuthorControllerTest.kt
@@ -1,10 +1,7 @@
 package com.bookmanagementsystem.presentation.controller.author
 
 import com.bookmanagementsystem.presentation.config.IntegrationTestWithSql
-import com.bookmanagementsystem.presentation.model.AuthorResponseModel
-import com.bookmanagementsystem.presentation.model.BadRequestErrorResponseModel
-import com.bookmanagementsystem.presentation.model.NotFoundErrorResponseModel
-import com.bookmanagementsystem.presentation.model.UpdateAuthorRequestModel
+import com.bookmanagementsystem.presentation.model.*
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.extensions.spring.SpringExtension
@@ -76,7 +73,7 @@ class UpdateAuthorControllerTest : FunSpec() {
                 response.id shouldBe 1
                 response.name shouldBe "更新された夏目漱石"
                 response.birthDate shouldBe LocalDate.of(1867, 2, 9)
-                response.version shouldBe 1
+                response.version shouldBe 2
             }
         }
 
@@ -133,6 +130,34 @@ class UpdateAuthorControllerTest : FunSpec() {
                 errorResponse.errors?.size shouldBe 1
                 errorResponse.errors?.first()?.code shouldBe "NOT_FOUND"
                 errorResponse.errors?.first()?.message shouldNotBe null
+            }
+        }
+
+        context("409") {
+            test("バージョンが古い場合楽観的ロック競合エラーが発生する") {
+                val request = UpdateAuthorRequestModel(
+                    name = "競合テスト用著者",
+                    version = 0, // 古いバージョン（現在のデータはversion=1）
+                    birthDate = LocalDate.of(1867, 2, 9)
+                )
+                val requestJson = objectMapper.writeValueAsString(request)
+
+                val result = mockMvc.perform(
+                    put("/api/authors/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestJson)
+                )
+                    .andExpect(status().isConflict)
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andReturn()
+
+                // OptimisticLockErrorResponseModel形式のレスポンス検証（OpenAPI準拠）
+                val responseJson = result.response.contentAsString
+                val errorResponse = objectMapper.readValue(responseJson, OptimisticLockErrorResponseModel::class.java)
+
+                errorResponse.errors?.size shouldBe 1
+                errorResponse.errors?.first()?.code shouldBe "OPTIMISTIC_LOCK_EXCEPTION"
+                errorResponse.errors?.first()?.message shouldBe "著者の更新に失敗しました。"
             }
         }
     }

--- a/presentation/src/test/kotlin/com/bookmanagementsystem/presentation/controller/author/UpdateAuthorControllerTest.kt
+++ b/presentation/src/test/kotlin/com/bookmanagementsystem/presentation/controller/author/UpdateAuthorControllerTest.kt
@@ -1,7 +1,11 @@
 package com.bookmanagementsystem.presentation.controller.author
 
 import com.bookmanagementsystem.presentation.config.IntegrationTestWithSql
-import com.bookmanagementsystem.presentation.model.*
+import com.bookmanagementsystem.presentation.model.AuthorResponseModel
+import com.bookmanagementsystem.presentation.model.BadRequestErrorResponseModel
+import com.bookmanagementsystem.presentation.model.NotFoundErrorResponseModel
+import com.bookmanagementsystem.presentation.model.OptimisticLockErrorResponseModel
+import com.bookmanagementsystem.presentation.model.UpdateAuthorRequestModel
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.extensions.spring.SpringExtension


### PR DESCRIPTION
## 概要
著者管理機能に楽観的ロック機能を実装し、同時更新によるデータ不整合を防止

## 詳細
| 項目 | 説明 |
| --- | --- |
| 楽観的ロック実装 | バージョン番号による同時更新検知 |
| 例外処理 | `OptimisticLockException`による409エラー |
| データベース操作 | WHERE句にバージョン条件を追加 |
| エラーレスポンス | 統一された`OptimisticLockErrorResponseModel`形式 |

## 備考
- 既存の著者データは自動的にバージョン1として扱われる
- 楽観的ロックエラー時は409ステータスコードが返される
- エラーレスポンスはOpenAPI仕様に準拠した形式

- [x] テスト実施