### PR TITLE
refactor: 著者に紐づく書籍APIを最適化

### DIFF
--- a/infrastructure/src/main/kotlin/com/bookmanagementsystem/infrastructure/book/BookQueryServiceImpl.kt
+++ b/infrastructure/src/main/kotlin/com/bookmanagementsystem/infrastructure/book/BookQueryServiceImpl.kt
@@ -1,50 +1,38 @@
 package com.bookmanagementsystem.infrastructure.book
 
 import com.bookmanagementsystem.domain.author.Author
+import com.bookmanagementsystem.domain.book.BookPrice
+import com.bookmanagementsystem.domain.book.BookPublishStatus
 import com.bookmanagementsystem.domain.core.ID
-import com.bookmanagementsystem.jooq.tables.references.AUTHOR
 import com.bookmanagementsystem.jooq.tables.references.AUTHOR_BOOK
 import com.bookmanagementsystem.jooq.tables.references.BOOK
-import com.bookmanagementsystem.usecase.book.BookDto
+import com.bookmanagementsystem.usecase.book.BookSummaryDto
 import com.bookmanagementsystem.usecase.book.read.BookQueryService
 import org.jooq.DSLContext
 import org.springframework.stereotype.Repository
 
 @Repository
 class BookQueryServiceImpl(private val dsl: DSLContext) : BookQueryService {
-    override fun findByAuthorId(authorId: ID<Author>): List<BookDto> {
-        val records = dsl.select(
+    override fun findByAuthorId(authorId: ID<Author>): List<BookSummaryDto> {
+        val records = dsl.selectDistinct(
             BOOK.ID,
             BOOK.TITLE,
             BOOK.PRICE,
             BOOK.PUBLISH_STATUS,
-            BOOK.VERSION,
-            AUTHOR.ID.`as`("author_id"),
-            AUTHOR.NAME.`as`("author_name"),
-            AUTHOR.BIRTH_DATE.`as`("author_birth_date"),
-            AUTHOR.VERSION.`as`("author_version")
         )
             .from(BOOK)
             .innerJoin(AUTHOR_BOOK).on(BOOK.ID.eq(AUTHOR_BOOK.BOOK_ID))
-            .innerJoin(AUTHOR).on(AUTHOR_BOOK.AUTHOR_ID.eq(AUTHOR.ID))
-            .where(
-                BOOK.ID.`in`(
-                    dsl.select(AUTHOR_BOOK.BOOK_ID)
-                        .from(AUTHOR_BOOK)
-                        .where(AUTHOR_BOOK.AUTHOR_ID.eq(authorId.value))
-                )
-            )
+            .where(AUTHOR_BOOK.AUTHOR_ID.eq(authorId.value))
             .orderBy(BOOK.ID)
             .fetch()
 
-        // NOTE: 著者に紐づく書籍が存在しない場合は空のリストを返す
-        if (records.isEmpty()) return emptyList()
-
-        val bookGroups = records.groupBy { it[BOOK.ID] }
-        return bookGroups.map { (_, bookRecords) ->
-            val bookRecord = bookRecords.first()
-            val authors = BookRecordConverter.convertAuthorDtoList(bookRecords)
-            BookRecordConverter.convert(bookRecord, authors)
+        return records.map { record ->
+            BookSummaryDto(
+                id = ID(record[BOOK.ID]!!),
+                title = record[BOOK.TITLE]!!,
+                price = BookPrice.of(record[BOOK.PRICE]!!),
+                status = BookPublishStatus.of(record[BOOK.PUBLISH_STATUS]!!),
+            )
         }
     }
 }

--- a/infrastructure/src/test/kotlin/com/bookmanagementsystem/infrastructure/book/BookQueryServiceImplTest.kt
+++ b/infrastructure/src/test/kotlin/com/bookmanagementsystem/infrastructure/book/BookQueryServiceImplTest.kt
@@ -1,7 +1,6 @@
 package com.bookmanagementsystem.infrastructure.book
 
 import com.bookmanagementsystem.domain.author.Author
-import com.bookmanagementsystem.domain.author.AuthorBirthDate
 import com.bookmanagementsystem.domain.book.BookPrice
 import com.bookmanagementsystem.domain.book.BookPublishStatus
 import com.bookmanagementsystem.domain.core.ID
@@ -11,12 +10,11 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.extensions.spring.SpringExtension
 import io.kotest.matchers.shouldBe
 import java.math.BigDecimal
-import java.time.LocalDate
 
 /**
  * BookQueryServiceImpl の統合テスト。
  *
- * 実際にデータベースに対してクエリを実行し、著者IDに紐づく書籍一覧の取得機能を検証する。
+ * 実際にデータベースに対してクエリを実行し、著者IDに紐づく書籍サマリー一覧の取得機能を検証する。
  * モックではなく実際の環境に近い構成（Spring Boot + PostgreSQL）で実行される。
  *
  * インフラストラクチャ層として、データベースからの正確なデータ取得を保証する目的。
@@ -27,7 +25,7 @@ class BookQueryServiceImplTest(private val bookQueryService: BookQueryService) :
 
     init {
         context("正常系") {
-            test("著者IDに紐づく書籍が正常に取得される") {
+            test("著者IDに紐づく書籍サマリーが正常に取得される") {
                 val authorId = ID<Author>(1)
 
                 val books = bookQueryService.findByAuthorId(authorId)
@@ -40,22 +38,15 @@ class BookQueryServiceImplTest(private val bookQueryService: BookQueryService) :
                 book1.title shouldBe "吾輩は猫である"
                 book1.price shouldBe BookPrice.of(BigDecimal("1500.00"))
                 book1.status shouldBe BookPublishStatus.PUBLISHED
-                book1.version shouldBe 1
-                book1.authors.size shouldBe 1
-                book1.authors[0].id.value shouldBe 1
-                book1.authors[0].name shouldBe "夏目漱石"
-                book1.authors[0].birthDate shouldBe AuthorBirthDate(LocalDate.of(1867, 2, 9))
 
                 val book2 = books[1]
                 book2.id.value shouldBe 2
                 book2.title shouldBe "日本文学選集"
                 book2.price shouldBe BookPrice.of(BigDecimal("3000.00"))
                 book2.status shouldBe BookPublishStatus.PUBLISHED
-                book2.version shouldBe 1
-                book2.authors.size shouldBe 3
             }
 
-            test("著者IDに紐づく複数の書籍が正常に取得される") {
+            test("著者IDに紐づく複数の書籍サマリーが正常に取得される") {
                 val authorId = ID<Author>(2)
 
                 val books = bookQueryService.findByAuthorId(authorId)
@@ -68,44 +59,27 @@ class BookQueryServiceImplTest(private val bookQueryService: BookQueryService) :
                 book1.title shouldBe "日本文学選集"
                 book1.price shouldBe BookPrice.of(BigDecimal("3000.00"))
                 book1.status shouldBe BookPublishStatus.PUBLISHED
-                book1.version shouldBe 1
-                book1.authors.size shouldBe 3
 
                 val book2 = books[1]
                 book2.id.value shouldBe 4
                 book2.title shouldBe "文学論"
                 book2.price shouldBe BookPrice.of(BigDecimal("2500.00"))
                 book2.status shouldBe BookPublishStatus.PUBLISHED
-                book2.version shouldBe 1
-                book2.authors.size shouldBe 1
-                book2.authors[0].id.value shouldBe 2
-                book2.authors[0].name shouldBe "太宰治"
-                book2.authors[0].birthDate shouldBe AuthorBirthDate(LocalDate.of(1909, 6, 19))
             }
 
-            test("共著書籍の場合、すべての著者情報が正常に取得される") {
+            test("共著書籍のサマリーが正常に取得される") {
                 val authorId = ID<Author>(1)
 
                 val books = bookQueryService.findByAuthorId(authorId)
                 val collaborativeBook = books.find { it.id.value == 2 }
 
-                collaborativeBook!!.authors.size shouldBe 3
-
-                // 著者IDでソートされていることを前提に検証
-                collaborativeBook.authors[0].id.value shouldBe 1
-                collaborativeBook.authors[0].name shouldBe "夏目漱石"
-                collaborativeBook.authors[0].birthDate shouldBe AuthorBirthDate(LocalDate.of(1867, 2, 9))
-
-                collaborativeBook.authors[1].id.value shouldBe 2
-                collaborativeBook.authors[1].name shouldBe "太宰治"
-                collaborativeBook.authors[1].birthDate shouldBe AuthorBirthDate(LocalDate.of(1909, 6, 19))
-
-                collaborativeBook.authors[2].id.value shouldBe 3
-                collaborativeBook.authors[2].name shouldBe "芥川龍之介"
-                collaborativeBook.authors[2].birthDate shouldBe AuthorBirthDate(LocalDate.of(1892, 3, 1))
+                collaborativeBook!!.id.value shouldBe 2
+                collaborativeBook.title shouldBe "日本文学選集"
+                collaborativeBook.price shouldBe BookPrice.of(BigDecimal("3000.00"))
+                collaborativeBook.status shouldBe BookPublishStatus.PUBLISHED
             }
 
-            test("著者IDに紐づく単一の書籍が正常に取得される") {
+            test("著者IDに紐づく単一の書籍サマリーが正常に取得される") {
                 val authorId = ID<Author>(3)
 
                 val books = bookQueryService.findByAuthorId(authorId)
@@ -116,21 +90,16 @@ class BookQueryServiceImplTest(private val bookQueryService: BookQueryService) :
                 val collaborativeBook = books[0]
                 collaborativeBook.id.value shouldBe 2
                 collaborativeBook.title shouldBe "日本文学選集"
-                collaborativeBook.authors.size shouldBe 3
+                collaborativeBook.status shouldBe BookPublishStatus.PUBLISHED
 
                 val singleAuthorBook = books[1]
                 singleAuthorBook.id.value shouldBe 5
                 singleAuthorBook.title shouldBe "こころ"
                 singleAuthorBook.price shouldBe BookPrice.of(BigDecimal("1800.00"))
                 singleAuthorBook.status shouldBe BookPublishStatus.PUBLISHED
-                singleAuthorBook.version shouldBe 1
-                singleAuthorBook.authors.size shouldBe 1
-                singleAuthorBook.authors[0].id.value shouldBe 3
-                singleAuthorBook.authors[0].name shouldBe "芥川龍之介"
-                singleAuthorBook.authors[0].birthDate shouldBe AuthorBirthDate(LocalDate.of(1892, 3, 1))
             }
 
-            test("生年月日がnullの著者を持つ書籍が正常に取得される") {
+            test("生年月日がnullの著者を持つ書籍サマリーが正常に取得される") {
                 val authorId = ID<Author>(4)
 
                 val books = bookQueryService.findByAuthorId(authorId)
@@ -141,11 +110,6 @@ class BookQueryServiceImplTest(private val bookQueryService: BookQueryService) :
                 book.title shouldBe "謎の小説"
                 book.price shouldBe BookPrice.of(BigDecimal("2000.00"))
                 book.status shouldBe BookPublishStatus.PUBLISHED
-                book.version shouldBe 1
-                book.authors.size shouldBe 1
-                book.authors[0].id.value shouldBe 4
-                book.authors[0].name shouldBe "匿名作家"
-                book.authors[0].birthDate shouldBe null
             }
 
             test("存在しない著者IDの場合は空のリストが返される") {

--- a/presentation/detekt-baseline.xml
+++ b/presentation/detekt-baseline.xml
@@ -2,6 +2,7 @@
 <SmellBaseline>
   <ManuallySuppressedIssues/>
   <CurrentIssues>
+    <ID>EmptyClassBlock:AuthorBookResponseModel.kt$AuthorBookResponseModel${ }</ID>
     <ID>EmptyClassBlock:AuthorResponseModel.kt$AuthorResponseModel${ }</ID>
     <ID>EmptyClassBlock:BadRequestErrorResponseModel.kt$BadRequestErrorResponseModel${ }</ID>
     <ID>EmptyClassBlock:BookResponseModel.kt$BookResponseModel${ }</ID>
@@ -12,6 +13,7 @@
     <ID>EmptyClassBlock:OptimisticLockErrorResponseModel.kt$OptimisticLockErrorResponseModel${ }</ID>
     <ID>EmptyClassBlock:UpdateAuthorRequestModel.kt$UpdateAuthorRequestModel${ }</ID>
     <ID>EmptyClassBlock:UpdateBookRequestModel.kt$UpdateBookRequestModel${ }</ID>
+    <ID>ImportOrdering:AuthorBookResponseModel.kt$import com.fasterxml.jackson.annotation.JsonProperty import jakarta.validation.constraints.NotNull import jakarta.validation.constraints.Min import jakarta.validation.constraints.Max import jakarta.validation.constraints.Size import jakarta.validation.Valid import com.bookmanagementsystem.usecase.author.register.PastOnly</ID>
     <ID>ImportOrdering:AuthorResponseModel.kt$import com.fasterxml.jackson.annotation.JsonProperty import jakarta.validation.constraints.NotNull import jakarta.validation.constraints.Min import jakarta.validation.constraints.Max import jakarta.validation.constraints.Size import jakarta.validation.Valid import com.bookmanagementsystem.usecase.author.register.PastOnly</ID>
     <ID>ImportOrdering:BadRequestErrorResponseModel.kt$import com.fasterxml.jackson.annotation.JsonProperty import jakarta.validation.constraints.NotNull import jakarta.validation.constraints.Min import jakarta.validation.constraints.Max import jakarta.validation.constraints.Size import jakarta.validation.Valid import com.bookmanagementsystem.usecase.author.register.PastOnly</ID>
     <ID>ImportOrdering:BookResponseModel.kt$import com.fasterxml.jackson.annotation.JsonProperty import jakarta.validation.constraints.NotNull import jakarta.validation.constraints.Min import jakarta.validation.constraints.Max import jakarta.validation.constraints.Size import jakarta.validation.Valid import com.bookmanagementsystem.usecase.author.register.PastOnly</ID>
@@ -22,7 +24,7 @@
     <ID>ImportOrdering:OptimisticLockErrorResponseModel.kt$import com.fasterxml.jackson.annotation.JsonProperty import jakarta.validation.constraints.NotNull import jakarta.validation.constraints.Min import jakarta.validation.constraints.Max import jakarta.validation.constraints.Size import jakarta.validation.Valid import com.bookmanagementsystem.usecase.author.register.PastOnly</ID>
     <ID>ImportOrdering:UpdateAuthorRequestModel.kt$import com.fasterxml.jackson.annotation.JsonProperty import jakarta.validation.constraints.NotNull import jakarta.validation.constraints.Min import jakarta.validation.constraints.Max import jakarta.validation.constraints.Size import jakarta.validation.Valid import com.bookmanagementsystem.usecase.author.register.PastOnly</ID>
     <ID>ImportOrdering:UpdateBookRequestModel.kt$import com.fasterxml.jackson.annotation.JsonProperty import jakarta.validation.constraints.NotNull import jakarta.validation.constraints.Min import jakarta.validation.constraints.Max import jakarta.validation.constraints.Size import jakarta.validation.Valid import com.bookmanagementsystem.usecase.author.register.PastOnly</ID>
-    <ID>MagicNumber:BookResponseModel.kt$BookResponseModel$9999999999L</ID>
+    <ID>NoBlankLineBeforeRbrace:AuthorBookResponseModel.kt$AuthorBookResponseModel$ </ID>
     <ID>NoBlankLineBeforeRbrace:AuthorResponseModel.kt$AuthorResponseModel$ </ID>
     <ID>NoBlankLineBeforeRbrace:BadRequestErrorResponseModel.kt$BadRequestErrorResponseModel$ </ID>
     <ID>NoBlankLineBeforeRbrace:BookResponseModel.kt$BookResponseModel$ </ID>
@@ -34,6 +36,7 @@
     <ID>NoBlankLineBeforeRbrace:UpdateAuthorRequestModel.kt$UpdateAuthorRequestModel$ </ID>
     <ID>NoBlankLineBeforeRbrace:UpdateBookRequestModel.kt$UpdateBookRequestModel$ </ID>
     <ID>NoConsecutiveBlankLines:BookStatus.kt$BookStatus$ </ID>
+    <ID>NoEmptyClassBody:AuthorBookResponseModel.kt$AuthorBookResponseModel${ }</ID>
     <ID>NoEmptyClassBody:AuthorResponseModel.kt$AuthorResponseModel${ }</ID>
     <ID>NoEmptyClassBody:BadRequestErrorResponseModel.kt$BadRequestErrorResponseModel${ }</ID>
     <ID>NoEmptyClassBody:BookResponseModel.kt$BookResponseModel${ }</ID>
@@ -44,6 +47,7 @@
     <ID>NoEmptyClassBody:OptimisticLockErrorResponseModel.kt$OptimisticLockErrorResponseModel${ }</ID>
     <ID>NoEmptyClassBody:UpdateAuthorRequestModel.kt$UpdateAuthorRequestModel${ }</ID>
     <ID>NoEmptyClassBody:UpdateBookRequestModel.kt$UpdateBookRequestModel${ }</ID>
+    <ID>NoUnusedImports:AuthorBookResponseModel.kt$com.bookmanagementsystem.presentation.model.AuthorBookResponseModel.kt</ID>
     <ID>NoUnusedImports:AuthorResponseModel.kt$com.bookmanagementsystem.presentation.model.AuthorResponseModel.kt</ID>
     <ID>NoUnusedImports:BadRequestErrorResponseModel.kt$com.bookmanagementsystem.presentation.model.BadRequestErrorResponseModel.kt</ID>
     <ID>NoUnusedImports:BookResponseModel.kt$com.bookmanagementsystem.presentation.model.BookResponseModel.kt</ID>

--- a/presentation/src/main/kotlin/com/bookmanagementsystem/presentation/controller/author/book/ReadAuthorBookController.kt
+++ b/presentation/src/main/kotlin/com/bookmanagementsystem/presentation/controller/author/book/ReadAuthorBookController.kt
@@ -1,11 +1,10 @@
-package com.bookmanagementsystem.presentation.controller.author
+package com.bookmanagementsystem.presentation.controller.author.book
 
 import com.bookmanagementsystem.domain.core.ID
-import com.bookmanagementsystem.presentation.model.AuthorResponseModel
-import com.bookmanagementsystem.presentation.model.BookResponseModel
+import com.bookmanagementsystem.presentation.model.AuthorBookResponseModel
 import com.bookmanagementsystem.presentation.model.BookStatus
-import com.bookmanagementsystem.usecase.author.read.ReadAuthorBookUsecase
-import com.bookmanagementsystem.usecase.book.BookDto
+import com.bookmanagementsystem.usecase.author.book.read.ReadAuthorBookUsecase
+import com.bookmanagementsystem.usecase.book.BookSummaryDto
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RestController
@@ -14,27 +13,23 @@ import org.springframework.web.bind.annotation.RestController
 class ReadAuthorBookController(private val usecase: ReadAuthorBookUsecase) {
     /**
      * 著者に紐づく書籍一覧を取得する
+     *
+     * NOTE: 書籍情報で著者情報とバージョンを返さない理由
+     * - 著者ID指定での書籍取得時はauthorsフィールドは冗長のため除外
+     * - バージョン情報は更新操作時のみ必要であり、一覧取得時には不要なため
+     *
      */
     @GetMapping("/api/authors/{id}/books")
-    fun read(@PathVariable id: Int): List<BookResponseModel> {
+    fun read(@PathVariable id: Int): List<AuthorBookResponseModel> {
         val bookDtoList = usecase.execute(ID(id))
 
         return bookDtoList.map { toResponse(it) }
     }
 
-    private fun toResponse(dto: BookDto) = BookResponseModel(
+    private fun toResponse(dto: BookSummaryDto) = AuthorBookResponseModel(
         id = dto.id.value,
         title = dto.title,
         price = dto.price.toLong(),
-        authors = dto.authors.map {
-            AuthorResponseModel(
-                it.id.value,
-                it.name,
-                it.birthDate?.value,
-                it.version
-            )
-        },
         status = BookStatus.of(dto.status.value),
-        version = dto.version
     )
 }

--- a/presentation/src/main/kotlin/com/bookmanagementsystem/presentation/model/AuthorBookResponseModel.kt
+++ b/presentation/src/main/kotlin/com/bookmanagementsystem/presentation/model/AuthorBookResponseModel.kt
@@ -1,0 +1,37 @@
+package com.bookmanagementsystem.presentation.model
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.Min
+import jakarta.validation.constraints.Max
+import jakarta.validation.constraints.Size
+import jakarta.validation.Valid
+import com.bookmanagementsystem.usecase.author.register.PastOnly
+
+/**
+ * 著者に紐づく書籍のAPIで汎用的に使用するレスポンス情報
+ * @param id 書籍ID
+ * @param title 書籍タイトル
+ * @param price 書籍価格
+ * @param status BookStatus
+ */
+data class AuthorBookResponseModel(
+    /* 書籍ID */
+    @field:NotNull
+    @get:JsonProperty("id") val id: kotlin.Int?,
+
+    /* 書籍タイトル */
+    @field:NotNull
+    @get:JsonProperty("title") val title: kotlin.String?,
+
+    /* 書籍価格 */
+    @get:Min(0L)
+    @field:NotNull
+    @get:JsonProperty("price") val price: kotlin.Long?,
+
+    @field:Valid
+    @field:NotNull
+    @get:JsonProperty("status") val status: BookStatus?
+) {
+
+}

--- a/presentation/src/main/resources/openapi.yml
+++ b/presentation/src/main/resources/openapi.yml
@@ -112,7 +112,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/BookResponseModel'
+                  $ref: '#/components/schemas/AuthorBookResponseModel'
         '404':
           description: 著者が存在しない場合
           content:
@@ -334,6 +334,33 @@ components:
       required:
         - id
         - name
+
+    AuthorBookResponseModel:
+      type: object
+      description: 著者に紐づく書籍のAPIで汎用的に使用するレスポンス情報
+      properties:
+        id:
+          type: integer
+          format: int32
+          description: 書籍ID
+          example: 1
+        title:
+          type: string
+          description: 書籍タイトル
+          example: "人間失格"
+        price:
+          type: integer
+          format: int64
+          minimum: 0
+          description: 書籍価格
+          example: 1500
+        status:
+          $ref: '#/components/schemas/BookStatus'
+      required:
+        - id
+        - title
+        - price
+        - status
 
     BookResponseModel:
       type: object

--- a/presentation/src/test/kotlin/com/bookmanagementsystem/presentation/controller/author/ReadAuthorBookControllerTest.kt
+++ b/presentation/src/test/kotlin/com/bookmanagementsystem/presentation/controller/author/ReadAuthorBookControllerTest.kt
@@ -1,7 +1,7 @@
 package com.bookmanagementsystem.presentation.controller.author
 
 import com.bookmanagementsystem.presentation.config.IntegrationTestWithSql
-import com.bookmanagementsystem.presentation.model.BookResponseModel
+import com.bookmanagementsystem.presentation.model.AuthorBookResponseModel
 import com.bookmanagementsystem.presentation.model.BookStatus
 import com.bookmanagementsystem.presentation.model.NotFoundErrorResponseModel
 import com.fasterxml.jackson.core.type.TypeReference
@@ -17,7 +17,6 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import org.springframework.test.web.servlet.setup.MockMvcBuilders
 import org.springframework.web.context.WebApplicationContext
-import java.time.LocalDate
 
 /**
  * ReadAuthorBookController の統合テスト。
@@ -64,7 +63,7 @@ class ReadAuthorBookControllerTest : FunSpec() {
                 val responseJson = result.response.contentAsString
                 val response = objectMapper.readValue(
                     responseJson,
-                    object : TypeReference<List<BookResponseModel>>() {}
+                    object : TypeReference<List<AuthorBookResponseModel>>() {}
                 )
 
                 response.size shouldBe 2
@@ -75,12 +74,6 @@ class ReadAuthorBookControllerTest : FunSpec() {
                 book1.title shouldBe "吾輩は猫である"
                 book1.price shouldBe 1500L
                 book1.status shouldBe BookStatus.PUBLISHED
-                book1.version shouldBe 1
-                book1.authors?.size shouldBe 1
-                book1.authors?.get(0)?.id shouldBe 1
-                book1.authors?.get(0)?.name shouldBe "夏目漱石"
-                book1.authors?.get(0)?.birthDate shouldBe LocalDate.of(1867, 2, 9)
-                book1.authors?.get(0)?.version shouldBe 1
 
                 // 2冊目の書籍検証（共著）
                 val book2 = response[1]
@@ -88,8 +81,6 @@ class ReadAuthorBookControllerTest : FunSpec() {
                 book2.title shouldBe "日本文学選集"
                 book2.price shouldBe 3000L
                 book2.status shouldBe BookStatus.PUBLISHED
-                book2.version shouldBe 1
-                book2.authors?.size shouldBe 3
             }
 
             test("著者に紐づく書籍が存在しない場合、空の配列が返される") {
@@ -104,7 +95,7 @@ class ReadAuthorBookControllerTest : FunSpec() {
                 // レスポンスボディの検証
                 val responseJson = result.response.contentAsString
                 val response =
-                    objectMapper.readValue(responseJson, object : TypeReference<List<BookResponseModel>>() {})
+                    objectMapper.readValue(responseJson, object : TypeReference<List<AuthorBookResponseModel>>() {})
 
                 response.size shouldBe 0
             }
@@ -121,7 +112,7 @@ class ReadAuthorBookControllerTest : FunSpec() {
                 // レスポンスボディの検証
                 val responseJson = result.response.contentAsString
                 val response =
-                    objectMapper.readValue(responseJson, object : TypeReference<List<BookResponseModel>>() {})
+                    objectMapper.readValue(responseJson, object : TypeReference<List<AuthorBookResponseModel>>() {})
 
                 response.size shouldBe 2
 
@@ -129,11 +120,6 @@ class ReadAuthorBookControllerTest : FunSpec() {
                 val singleAuthorBook = response.find { it.id == 4 }
                 singleAuthorBook!!.title shouldBe "文学論"
                 singleAuthorBook.price shouldBe 2500L
-                singleAuthorBook.version shouldBe 1
-                singleAuthorBook.authors?.size shouldBe 1
-                singleAuthorBook.authors?.get(0)?.id shouldBe 2
-                singleAuthorBook.authors?.get(0)?.name shouldBe "太宰治"
-                singleAuthorBook.authors?.get(0)?.version shouldBe 1
             }
         }
 

--- a/usecase/src/main/kotlin/com/bookmanagementsystem/usecase/author/book/read/ReadAuthorBookUsecase.kt
+++ b/usecase/src/main/kotlin/com/bookmanagementsystem/usecase/author/book/read/ReadAuthorBookUsecase.kt
@@ -1,9 +1,9 @@
-package com.bookmanagementsystem.usecase.author.read
+package com.bookmanagementsystem.usecase.author.book.read
 
 import com.bookmanagementsystem.domain.author.Author
 import com.bookmanagementsystem.domain.author.AuthorRepository
 import com.bookmanagementsystem.domain.core.ID
-import com.bookmanagementsystem.usecase.book.BookDto
+import com.bookmanagementsystem.usecase.book.BookSummaryDto
 import com.bookmanagementsystem.usecase.book.read.BookQueryService
 import org.springframework.stereotype.Service
 
@@ -15,7 +15,7 @@ class ReadAuthorBookUsecase(
     /**
      * 指定された著者IDに紐づく書籍一覧を取得する
      */
-    fun execute(authorId: ID<Author>): List<BookDto> {
+    fun execute(authorId: ID<Author>): List<BookSummaryDto> {
         authorRepository.findById(authorId)
             ?: throw NoSuchElementException("著者が見つかりません。ID: ${authorId.value}")
 

--- a/usecase/src/main/kotlin/com/bookmanagementsystem/usecase/book/BookSummaryDto.kt
+++ b/usecase/src/main/kotlin/com/bookmanagementsystem/usecase/book/BookSummaryDto.kt
@@ -1,0 +1,16 @@
+package com.bookmanagementsystem.usecase.book
+
+import com.bookmanagementsystem.domain.book.Book
+import com.bookmanagementsystem.domain.book.BookPrice
+import com.bookmanagementsystem.domain.book.BookPublishStatus
+import com.bookmanagementsystem.domain.core.ID
+
+/**
+ * 書籍の要約情報を表すDTO
+ */
+data class BookSummaryDto(
+    val id: ID<Book>,
+    val title: String,
+    val price: BookPrice,
+    val status: BookPublishStatus,
+)

--- a/usecase/src/main/kotlin/com/bookmanagementsystem/usecase/book/read/BookQueryService.kt
+++ b/usecase/src/main/kotlin/com/bookmanagementsystem/usecase/book/read/BookQueryService.kt
@@ -2,11 +2,11 @@ package com.bookmanagementsystem.usecase.book.read
 
 import com.bookmanagementsystem.domain.author.Author
 import com.bookmanagementsystem.domain.core.ID
-import com.bookmanagementsystem.usecase.book.BookDto
+import com.bookmanagementsystem.usecase.book.BookSummaryDto
 
 interface BookQueryService {
     /**
      * 著者IDに紐づく書籍一覧を取得する
      */
-    fun findByAuthorId(authorId: ID<Author>): List<BookDto>
+    fun findByAuthorId(authorId: ID<Author>): List<BookSummaryDto>
 }

--- a/usecase/src/test/kotlin/com/bookmanagementsystem/usecase/author/book/read/ReadAuthorBookUsecaseTest.kt
+++ b/usecase/src/test/kotlin/com/bookmanagementsystem/usecase/author/book/read/ReadAuthorBookUsecaseTest.kt
@@ -1,4 +1,4 @@
-package com.bookmanagementsystem.usecase.author.read
+package com.bookmanagementsystem.usecase.author.book.read
 
 import com.bookmanagementsystem.domain.author.Author
 import com.bookmanagementsystem.domain.author.AuthorBirthDate
@@ -6,8 +6,7 @@ import com.bookmanagementsystem.domain.author.AuthorRepository
 import com.bookmanagementsystem.domain.book.BookPrice
 import com.bookmanagementsystem.domain.book.BookPublishStatus
 import com.bookmanagementsystem.domain.core.ID
-import com.bookmanagementsystem.usecase.author.AuthorDto
-import com.bookmanagementsystem.usecase.book.BookDto
+import com.bookmanagementsystem.usecase.book.BookSummaryDto
 import com.bookmanagementsystem.usecase.book.read.BookQueryService
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
@@ -30,35 +29,17 @@ class ReadAuthorBookUsecaseTest : FunSpec({
             birthDate = AuthorBirthDate(LocalDate.of(1867, 2, 9))
         )
         val expectedBooks = listOf(
-            BookDto(
+            BookSummaryDto(
                 id = ID(1),
                 title = "吾輩は猫である",
                 price = BookPrice.of(BigDecimal("1500.00")),
-                authors = listOf(
-                    AuthorDto(
-                        id = ID(1),
-                        name = "夏目漱石",
-                        birthDate = AuthorBirthDate(LocalDate.of(1867, 2, 9)),
-                        version = 1
-                    )
-                ),
-                status = BookPublishStatus.PUBLISHED,
-                version = 1
+                status = BookPublishStatus.PUBLISHED
             ),
-            BookDto(
+            BookSummaryDto(
                 id = ID(2),
                 title = "こころ",
                 price = BookPrice.of(BigDecimal("1800.00")),
-                authors = listOf(
-                    AuthorDto(
-                        id = ID(1),
-                        name = "夏目漱石",
-                        birthDate = AuthorBirthDate(LocalDate.of(1867, 2, 9)),
-                        version = 1
-                    )
-                ),
-                status = BookPublishStatus.PUBLISHED,
-                version = 1
+                status = BookPublishStatus.PUBLISHED
             )
         )
 
@@ -121,32 +102,11 @@ class ReadAuthorBookUsecaseTest : FunSpec({
             birthDate = AuthorBirthDate(LocalDate.of(1867, 2, 9))
         )
         val expectedBooks = listOf(
-            BookDto(
+            BookSummaryDto(
                 id = ID(1),
                 title = "日本文学選集",
                 price = BookPrice.of(BigDecimal("3000.00")),
-                authors = listOf(
-                    AuthorDto(
-                        id = ID(1),
-                        name = "夏目漱石",
-                        birthDate = AuthorBirthDate(LocalDate.of(1867, 2, 9)),
-                        version = 1
-                    ),
-                    AuthorDto(
-                        id = ID(2),
-                        name = "太宰治",
-                        birthDate = AuthorBirthDate(LocalDate.of(1909, 6, 19)),
-                        version = 1
-                    ),
-                    AuthorDto(
-                        id = ID(3),
-                        name = "芥川龍之介",
-                        birthDate = AuthorBirthDate(LocalDate.of(1892, 3, 1)),
-                        version = 1
-                    )
-                ),
-                status = BookPublishStatus.PUBLISHED,
-                version = 1
+                status = BookPublishStatus.PUBLISHED
             )
         )
 
@@ -156,7 +116,6 @@ class ReadAuthorBookUsecaseTest : FunSpec({
         val result = usecase.execute(authorId)
 
         result shouldBe expectedBooks
-        result[0].authors.size shouldBe 3
         verify { authorRepository.findById(authorId) }
         verify { bookQueryService.findByAuthorId(authorId) }
     }


### PR DESCRIPTION
## 概要
著者に紐づく書籍APIのレスポンスを最適化し、不要な情報を除外してパフォーマンスと可読性を向上

### 最適化の理由
- **著者情報の冗長性**: 著者ID指定での書籍取得時は著者情報が不要
- **バージョン情報の不要性**: 一覧取得時には楽観的ロック用のバージョンが不要
- **パフォーマンス向上**: 不要なJOINとデータ取得を削減
- **API設計の改善**: 用途に応じた適切なレスポンス設計

### 変更されたファイル
- インフラストラクチャ層のクエリ実装
- プレゼンテーション層のコントローラーとモデル
- ユースケース層のDTOとサービス
- テストファイルの更新

## 備考
- 既存のAPIエンドポイント（`/api/authors/{id}/books`）は維持
- レスポンス形式が変更されるため、クライアント側の対応が必要
- パフォーマンスが向上し、ネットワーク負荷が軽減

- [x] テスト実施