### PR TITLE
feat: 著者IDの重複チェック機能を追加

### DIFF
--- a/usecase/src/main/kotlin/com/bookmanagementsystem/usecase/book/register/BookRegisterCommand.kt
+++ b/usecase/src/main/kotlin/com/bookmanagementsystem/usecase/book/register/BookRegisterCommand.kt
@@ -5,6 +5,7 @@ import com.bookmanagementsystem.domain.book.Book
 import com.bookmanagementsystem.domain.book.BookPrice
 import com.bookmanagementsystem.domain.book.BookPublishStatus
 import com.bookmanagementsystem.domain.core.ID
+import com.bookmanagementsystem.usecase.validation.core.UniqueId
 
 sealed interface BookRegisterCommand
 
@@ -14,6 +15,7 @@ sealed interface BookRegisterCommand
 data class CreateBookCommand(
     val title: String,
     val price: BookPrice,
+    @UniqueId
     val authorIds: List<ID<Author>>,
     val status: BookPublishStatus,
 ) : BookRegisterCommand
@@ -26,6 +28,7 @@ data class UpdateBookCommand(
     val id: ID<Book>,
     val title: String,
     val price: BookPrice,
+    @UniqueId
     val authorIds: List<ID<Author>>,
     val status: BookPublishStatus,
     val version: Int,

--- a/usecase/src/main/kotlin/com/bookmanagementsystem/usecase/book/register/CreateBookUsecase.kt
+++ b/usecase/src/main/kotlin/com/bookmanagementsystem/usecase/book/register/CreateBookUsecase.kt
@@ -4,17 +4,23 @@ import com.bookmanagementsystem.domain.book.Book
 import com.bookmanagementsystem.domain.book.BookRepository
 import com.bookmanagementsystem.usecase.book.BookDto
 import com.bookmanagementsystem.usecase.book.read.BookDetailQueryService
+import com.bookmanagementsystem.usecase.exception.UsecaseViolationException
+import com.bookmanagementsystem.usecase.validation.CommandValidator
 import org.springframework.stereotype.Service
 
 @Service
 class CreateBookUsecase(
     private val repository: BookRepository,
+    private val validator: CommandValidator,
     private val detailQueryService: BookDetailQueryService,
 ) {
     /**
      * 書籍を登録する
      */
     fun execute(command: CreateBookCommand): BookDto {
+        val validationErrors = validator.validate(command)
+        if (validationErrors.isNotEmpty()) throw UsecaseViolationException(validationErrors)
+
         val book = repository.insert(toEntity(command))
 
         return detailQueryService.findById(book.id!!)!!

--- a/usecase/src/main/kotlin/com/bookmanagementsystem/usecase/book/register/UpdateBookUsecase.kt
+++ b/usecase/src/main/kotlin/com/bookmanagementsystem/usecase/book/register/UpdateBookUsecase.kt
@@ -22,7 +22,7 @@ class UpdateBookUsecase(
             repository.findById(command.id) ?: throw NoSuchElementException("書籍が存在しません: ${command.id}")
 
         val validationErrors = validator.validate(command)
-        if (validationErrors.isNotEmpty()) throw UsecaseViolationException(validationErrors.joinToString(", "))
+        if (validationErrors.isNotEmpty()) throw UsecaseViolationException(validationErrors)
 
         val book = repository.update(toEntity(currentBook, command))
 

--- a/usecase/src/main/kotlin/com/bookmanagementsystem/usecase/validation/core/UniqueIdValidator.kt
+++ b/usecase/src/main/kotlin/com/bookmanagementsystem/usecase/validation/core/UniqueIdValidator.kt
@@ -1,0 +1,31 @@
+package com.bookmanagementsystem.usecase.validation.core
+
+import com.bookmanagementsystem.domain.core.ID
+import jakarta.validation.Constraint
+import jakarta.validation.ConstraintValidator
+import jakarta.validation.ConstraintValidatorContext
+import jakarta.validation.Payload
+import kotlin.reflect.KClass
+
+/**
+ * リスト内の要素が重複していないことを検証するアノテーション
+ */
+@Target(AnnotationTarget.FIELD, AnnotationTarget.PROPERTY_GETTER)
+@Retention(AnnotationRetention.RUNTIME)
+@Constraint(validatedBy = [UniqueIdValidator::class])
+@MustBeDocumented
+annotation class UniqueId(
+    val message: String = "リスト内に重複した要素があります",
+    val groups: Array<KClass<*>> = [],
+    val payload: Array<KClass<out Payload>> = []
+)
+
+class UniqueIdValidator : ConstraintValidator<UniqueId, List<ID<*>>> {
+    /**
+     * 配列内のIDが重複していないかを検証する
+     */
+    override fun isValid(value: List<ID<*>>, context: ConstraintValidatorContext?): Boolean {
+        // リストのサイズと重複を除いたSetのサイズが同じかチェック
+        return value.size == value.toSet().size
+    }
+}

--- a/usecase/src/main/kotlin/com/bookmanagementsystem/usecase/validation/core/UniqueIdValidator.kt
+++ b/usecase/src/main/kotlin/com/bookmanagementsystem/usecase/validation/core/UniqueIdValidator.kt
@@ -22,7 +22,7 @@ annotation class UniqueId(
 
 class UniqueIdValidator : ConstraintValidator<UniqueId, List<ID<*>>> {
     /**
-     * 配列内のIDが重複していないかを検証する
+     * リスト内のIDが重複していないかを検証する
      */
     override fun isValid(value: List<ID<*>>, context: ConstraintValidatorContext?): Boolean {
         // リストのサイズと重複を除いたSetのサイズが同じかチェック

--- a/usecase/src/test/kotlin/com/bookmanagementsystem/usecase/book/register/CreateBookUsecaseTest.kt
+++ b/usecase/src/test/kotlin/com/bookmanagementsystem/usecase/book/register/CreateBookUsecaseTest.kt
@@ -9,18 +9,28 @@ import com.bookmanagementsystem.domain.core.ID
 import com.bookmanagementsystem.usecase.author.AuthorDto
 import com.bookmanagementsystem.usecase.book.BookDto
 import com.bookmanagementsystem.usecase.book.read.BookDetailQueryService
+import com.bookmanagementsystem.usecase.exception.UsecaseViolationException
+import com.bookmanagementsystem.usecase.validation.CommandValidator
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
+import io.mockk.clearMocks
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import java.time.LocalDate
 
 class CreateBookUsecaseTest : FunSpec({
+    val repository = mockk<BookRepository>()
+    val validator = mockk<CommandValidator>()
+    val detailQueryService = mockk<BookDetailQueryService>()
+    val usecase = CreateBookUsecase(repository, validator, detailQueryService)
+
+    beforeEach {
+        clearMocks(repository, validator, detailQueryService)
+    }
+
     test("書籍登録が正常に実行されること") {
-        val repository = mockk<BookRepository>()
-        val detailQueryService = mockk<BookDetailQueryService>()
-        val usecase = CreateBookUsecase(repository, detailQueryService)
 
         val command = CreateBookCommand(
             title = "テスト書籍",
@@ -53,6 +63,7 @@ class CreateBookUsecaseTest : FunSpec({
             )
         )
 
+        every { validator.validate(command) } returns emptyList()
         every { repository.insert(any()) } returns savedBook
         every { detailQueryService.findById(ID(1)) } returns BookDto(
             id = ID(1),
@@ -75,6 +86,7 @@ class CreateBookUsecaseTest : FunSpec({
         )
 
         verify {
+            validator.validate(command)
             repository.insert(
                 Book(
                     title = "テスト書籍",
@@ -83,16 +95,11 @@ class CreateBookUsecaseTest : FunSpec({
                     status = BookPublishStatus.PUBLISHED
                 )
             )
-        }
-        verify {
             detailQueryService.findById(ID(1))
         }
     }
 
     test("未出版ステータスの書籍登録が正常に実行されること") {
-        val repository = mockk<BookRepository>()
-        val detailQueryService = mockk<BookDetailQueryService>()
-        val usecase = CreateBookUsecase(repository, detailQueryService)
 
         val command = CreateBookCommand(
             title = "未出版書籍",
@@ -119,6 +126,7 @@ class CreateBookUsecaseTest : FunSpec({
             )
         )
 
+        every { validator.validate(command) } returns emptyList()
         every { repository.insert(any()) } returns savedBook
         every { detailQueryService.findById(ID(2)) } returns BookDto(
             id = ID(2),
@@ -141,6 +149,7 @@ class CreateBookUsecaseTest : FunSpec({
         )
 
         verify {
+            validator.validate(command)
             repository.insert(
                 Book(
                     title = "未出版書籍",
@@ -149,13 +158,11 @@ class CreateBookUsecaseTest : FunSpec({
                     status = BookPublishStatus.UNPUBLISHED
                 )
             )
+            detailQueryService.findById(ID(2))
         }
     }
 
     test("複数著者の書籍登録が正常に実行されること") {
-        val repository = mockk<BookRepository>()
-        val detailQueryService = mockk<BookDetailQueryService>()
-        val usecase = CreateBookUsecase(repository, detailQueryService)
 
         val command = CreateBookCommand(
             title = "共著書籍",
@@ -194,6 +201,7 @@ class CreateBookUsecaseTest : FunSpec({
             )
         )
 
+        every { validator.validate(command) } returns emptyList()
         every { repository.insert(any()) } returns savedBook
         every { detailQueryService.findById(ID(3)) } returns BookDto(
             id = ID(3),
@@ -216,6 +224,7 @@ class CreateBookUsecaseTest : FunSpec({
         )
 
         verify {
+            validator.validate(command)
             repository.insert(
                 Book(
                     title = "共著書籍",
@@ -224,6 +233,61 @@ class CreateBookUsecaseTest : FunSpec({
                     status = BookPublishStatus.PUBLISHED
                 )
             )
+            detailQueryService.findById(ID(3))
+        }
+    }
+
+    test("重複した著者IDがある場合UsecaseViolationExceptionがスローされること") {
+        val command = CreateBookCommand(
+            title = "重複著者テスト書籍",
+            price = BookPrice.of(1000L),
+            authorIds = listOf(ID(1), ID(2), ID(1)), // 著者ID 1が重複
+            status = BookPublishStatus.PUBLISHED
+        )
+        val validationErrors = listOf("authorIds: リスト内に重複した要素があります")
+
+        every { validator.validate(command) } returns validationErrors
+
+        val exception = shouldThrow<UsecaseViolationException> {
+            usecase.execute(command)
+        }
+        exception.errors shouldBe listOf("authorIds: リスト内に重複した要素があります")
+        verify {
+            validator.validate(command)
+        }
+        verify(exactly = 0) {
+            repository.insert(any<Book>())
+            detailQueryService.findById(any<ID<Book>>())
+        }
+    }
+
+    test("複数のバリデーションエラーがある場合UsecaseViolationExceptionがスローされること") {
+        val command = CreateBookCommand(
+            title = "", // 空のタイトル（Pattern違反）
+            price = BookPrice.of(1000L),
+            authorIds = listOf(ID(1), ID(2), ID(1)), // 著者ID 1が重複
+            status = BookPublishStatus.PUBLISHED
+        )
+        val validationErrors = listOf(
+            "title: タイトルは空白文字のみで構成することはできません",
+            "authorIds: リスト内に重複した要素があります"
+        )
+
+        every { validator.validate(command) } returns validationErrors
+
+        val exception = shouldThrow<UsecaseViolationException> {
+            usecase.execute(command)
+        }
+        exception.errors shouldBe listOf(
+            "title: タイトルは空白文字のみで構成することはできません",
+            "authorIds: リスト内に重複した要素があります"
+        )
+        verify {
+            validator.validate(command)
+        }
+        verify(exactly = 0) {
+            repository.insert(any<Book>())
+            detailQueryService.findById(any<ID<Book>>())
         }
     }
 })

--- a/usecase/src/test/kotlin/com/bookmanagementsystem/usecase/validation/core/UniqueIdValidatorTest.kt
+++ b/usecase/src/test/kotlin/com/bookmanagementsystem/usecase/validation/core/UniqueIdValidatorTest.kt
@@ -1,0 +1,64 @@
+package com.bookmanagementsystem.usecase.validation.core
+
+import com.bookmanagementsystem.domain.author.Author
+import com.bookmanagementsystem.domain.core.ID
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * UniqueIdValidatorのテスト
+ */
+class UniqueIdValidatorTest : FunSpec({
+    val validator = UniqueIdValidator()
+
+    context("ID重複チェックのバリデーション") {
+        test("重複のないIDリストの場合はtrue") {
+            val uniqueIds: List<ID<Author>> = listOf(ID(1), ID(2), ID(3))
+            val result = validator.isValid(uniqueIds, null)
+
+            result shouldBe true
+        }
+
+        test("重複のあるIDリストの場合はfalse") {
+            val duplicateIds: List<ID<Author>> = listOf(ID(1), ID(2), ID(1))
+            val result = validator.isValid(duplicateIds, null)
+
+            result shouldBe false
+        }
+
+        test("空のIDリストの場合はtrue") {
+            val emptyIds = emptyList<ID<Author>>()
+            val result = validator.isValid(emptyIds, null)
+
+            result shouldBe true
+        }
+
+        test("単一のIDの場合はtrue") {
+            val singleId = listOf(ID<Author>(1))
+            val result = validator.isValid(singleId, null)
+
+            result shouldBe true
+        }
+
+        test("同じIDが複数回含まれる場合はfalse") {
+            val sameIds: List<ID<Author>> = listOf(ID(5), ID(5), ID(5))
+            val result = validator.isValid(sameIds, null)
+
+            result shouldBe false
+        }
+
+        test("連続する重複IDがある場合はfalse") {
+            val consecutiveDuplicates: List<ID<Author>> = listOf(ID(1), ID(1), ID(2))
+            val result = validator.isValid(consecutiveDuplicates, null)
+
+            result shouldBe false
+        }
+
+        test("非連続の重複IDがある場合はfalse") {
+            val nonConsecutiveDuplicates: List<ID<Author>> = listOf(ID(1), ID(2), ID(3), ID(1))
+            val result = validator.isValid(nonConsecutiveDuplicates, null)
+
+            result shouldBe false
+        }
+    }
+})


### PR DESCRIPTION
## 概要
書籍登録・更新時に著者IDの重複を検証するバリデーション機能を実装し、データの整合性を向上

## 詳細
#### 1. カスタムバリデーションアノテーションの実装
- `@UniqueId`アノテーションを新規作成
- `UniqueIdValidator`クラスで重複チェックロジックを実装
- Jakarta Validationフレームワークと統合

## 備考
- 既存のAPIエンドポイントの動作は維持
- 重複IDを送信した場合、400エラーとバリデーションエラーメッセージが返される
- 他のバリデーションエラーと組み合わせて複数のエラーを同時に検出可能

- [x] テスト実施