### PR TITLE
feat: 著者IDの存在チェック機能を追加

### DIFF
--- a/domain/src/main/kotlin/com/bookmanagementsystem/domain/author/AuthorRepository.kt
+++ b/domain/src/main/kotlin/com/bookmanagementsystem/domain/author/AuthorRepository.kt
@@ -9,6 +9,11 @@ interface AuthorRepository {
     fun findById(id: ID<Author>): Author?
 
     /**
+     * 著者のIDリストに合う著者を取得する
+     */
+    fun findByIds(ids: List<ID<Author>>): List<Author>
+
+    /**
      * 著者を登録する
      */
     fun insert(author: Author): Author

--- a/infrastructure/src/main/kotlin/com/bookmanagementsystem/infrastructure/author/AuthorRepositoryImpl.kt
+++ b/infrastructure/src/main/kotlin/com/bookmanagementsystem/infrastructure/author/AuthorRepositoryImpl.kt
@@ -18,6 +18,12 @@ class AuthorRepositoryImpl(private val dsl: DSLContext) : AuthorRepository {
         .fetchOne()
         ?.let { convert(it) }
 
+    override fun findByIds(ids: List<ID<Author>>): List<Author> = dsl
+        .selectFrom(AUTHOR)
+        .where(AUTHOR.ID.`in`(ids.map { it.value }))
+        .fetch()
+        .map { convert(it) }
+
     override fun insert(author: Author) = dsl
         .insertInto(AUTHOR)
         .set(AUTHOR.NAME, author.name)

--- a/usecase/build.gradle
+++ b/usecase/build.gradle
@@ -9,6 +9,7 @@ dependencyManagement {
 dependencies {
 	implementation project(':domain')
 	implementation 'org.springframework:spring-context'
+	implementation 'org.springframework:spring-tx'
 	implementation 'jakarta.validation:jakarta.validation-api'
 	testImplementation 'io.mockk:mockk:1.13.8'
 }

--- a/usecase/src/main/kotlin/com/bookmanagementsystem/usecase/author/AuthorExistsValidator.kt
+++ b/usecase/src/main/kotlin/com/bookmanagementsystem/usecase/author/AuthorExistsValidator.kt
@@ -1,0 +1,37 @@
+package com.bookmanagementsystem.usecase.author
+
+import com.bookmanagementsystem.domain.author.Author
+import com.bookmanagementsystem.domain.author.AuthorRepository
+import com.bookmanagementsystem.domain.core.ID
+import jakarta.validation.Constraint
+import jakarta.validation.ConstraintValidator
+import jakarta.validation.ConstraintValidatorContext
+import jakarta.validation.Payload
+import kotlin.reflect.KClass
+
+@Target(AnnotationTarget.FIELD, AnnotationTarget.PROPERTY_GETTER)
+@Retention(AnnotationRetention.RUNTIME)
+@Constraint(validatedBy = [AuthorExistsValidator::class])
+@MustBeDocumented
+annotation class AuthorExists(
+    val message: String = "存在しない著者が指定されています",
+    val groups: Array<KClass<*>> = [],
+    val payload: Array<KClass<out Payload>> = []
+)
+
+/**
+ * 著者が存在するかどうかを検証するバリデータ
+ */
+class AuthorExistsValidator(
+    private val repository: AuthorRepository
+) : ConstraintValidator<AuthorExists, List<ID<Author>>> {
+
+    override fun isValid(value: List<ID<Author>>, context: ConstraintValidatorContext?): Boolean {
+        return value.isEmpty() || existsAll(value.distinct())
+    }
+
+    private fun existsAll(ids: List<ID<Author>>): Boolean {
+        val authors = repository.findByIds(ids)
+        return authors.size == ids.size
+    }
+}

--- a/usecase/src/main/kotlin/com/bookmanagementsystem/usecase/author/book/read/ReadAuthorBookUsecase.kt
+++ b/usecase/src/main/kotlin/com/bookmanagementsystem/usecase/author/book/read/ReadAuthorBookUsecase.kt
@@ -16,7 +16,7 @@ class ReadAuthorBookUsecase(
     /**
      * 指定された著者IDに紐づく書籍一覧を取得する
      */
-    @Transactional
+    @Transactional(readOnly = true)
     fun execute(authorId: ID<Author>): List<BookSummaryDto> {
         authorRepository.findById(authorId)
             ?: throw NoSuchElementException("著者が見つかりません。ID: ${authorId.value}")

--- a/usecase/src/main/kotlin/com/bookmanagementsystem/usecase/author/book/read/ReadAuthorBookUsecase.kt
+++ b/usecase/src/main/kotlin/com/bookmanagementsystem/usecase/author/book/read/ReadAuthorBookUsecase.kt
@@ -6,6 +6,7 @@ import com.bookmanagementsystem.domain.core.ID
 import com.bookmanagementsystem.usecase.book.BookSummaryDto
 import com.bookmanagementsystem.usecase.book.read.BookQueryService
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 
 @Service
 class ReadAuthorBookUsecase(
@@ -15,6 +16,7 @@ class ReadAuthorBookUsecase(
     /**
      * 指定された著者IDに紐づく書籍一覧を取得する
      */
+    @Transactional
     fun execute(authorId: ID<Author>): List<BookSummaryDto> {
         authorRepository.findById(authorId)
             ?: throw NoSuchElementException("著者が見つかりません。ID: ${authorId.value}")

--- a/usecase/src/main/kotlin/com/bookmanagementsystem/usecase/author/register/CreateAuthorUsecase.kt
+++ b/usecase/src/main/kotlin/com/bookmanagementsystem/usecase/author/register/CreateAuthorUsecase.kt
@@ -4,12 +4,14 @@ import com.bookmanagementsystem.domain.author.Author
 import com.bookmanagementsystem.domain.author.AuthorRepository
 import com.bookmanagementsystem.usecase.author.AuthorDto
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 
 @Service
 class CreateAuthorUsecase(private val repository: AuthorRepository) {
     /**
      * 著者を登録する
      */
+    @Transactional
     fun execute(command: CreateAuthorCommand): AuthorDto {
         val author = repository.insert(toEntity(command))
         return toDto(author)

--- a/usecase/src/main/kotlin/com/bookmanagementsystem/usecase/author/register/UpdateAuthorUsecase.kt
+++ b/usecase/src/main/kotlin/com/bookmanagementsystem/usecase/author/register/UpdateAuthorUsecase.kt
@@ -4,12 +4,14 @@ import com.bookmanagementsystem.domain.author.Author
 import com.bookmanagementsystem.domain.author.AuthorRepository
 import com.bookmanagementsystem.usecase.author.AuthorDto
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 
 @Service
 class UpdateAuthorUsecase(private val repository: AuthorRepository) {
     /**
      * 著者を更新する
      */
+    @Transactional
     fun execute(command: UpdateAuthorCommand): AuthorDto {
         repository.findById(command.id) ?: throw NoSuchElementException("著者が見つかりません: ${command.id}")
 

--- a/usecase/src/main/kotlin/com/bookmanagementsystem/usecase/book/register/BookRegisterCommand.kt
+++ b/usecase/src/main/kotlin/com/bookmanagementsystem/usecase/book/register/BookRegisterCommand.kt
@@ -5,6 +5,7 @@ import com.bookmanagementsystem.domain.book.Book
 import com.bookmanagementsystem.domain.book.BookPrice
 import com.bookmanagementsystem.domain.book.BookPublishStatus
 import com.bookmanagementsystem.domain.core.ID
+import com.bookmanagementsystem.usecase.author.AuthorExists
 import com.bookmanagementsystem.usecase.validation.core.UniqueId
 
 sealed interface BookRegisterCommand
@@ -16,6 +17,7 @@ data class CreateBookCommand(
     val title: String,
     val price: BookPrice,
     @UniqueId
+    @AuthorExists
     val authorIds: List<ID<Author>>,
     val status: BookPublishStatus,
 ) : BookRegisterCommand
@@ -29,6 +31,7 @@ data class UpdateBookCommand(
     val title: String,
     val price: BookPrice,
     @UniqueId
+    @AuthorExists
     val authorIds: List<ID<Author>>,
     val status: BookPublishStatus,
     val version: Int,

--- a/usecase/src/main/kotlin/com/bookmanagementsystem/usecase/book/register/CreateBookUsecase.kt
+++ b/usecase/src/main/kotlin/com/bookmanagementsystem/usecase/book/register/CreateBookUsecase.kt
@@ -7,6 +7,7 @@ import com.bookmanagementsystem.usecase.book.read.BookDetailQueryService
 import com.bookmanagementsystem.usecase.exception.UsecaseViolationException
 import com.bookmanagementsystem.usecase.validation.CommandValidator
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 
 @Service
 class CreateBookUsecase(
@@ -19,8 +20,9 @@ class CreateBookUsecase(
      */
     @Transactional
     fun execute(command: CreateBookCommand): BookDto {
-        val validationErrors = validator.validate(command)
-        if (validationErrors.isNotEmpty()) throw UsecaseViolationException(validationErrors)
+        validator.validate(command).let {
+            if (it.isNotEmpty()) throw UsecaseViolationException(it)
+        }
 
         val book = repository.insert(toEntity(command))
 

--- a/usecase/src/main/kotlin/com/bookmanagementsystem/usecase/book/register/CreateBookUsecase.kt
+++ b/usecase/src/main/kotlin/com/bookmanagementsystem/usecase/book/register/CreateBookUsecase.kt
@@ -17,6 +17,7 @@ class CreateBookUsecase(
     /**
      * 書籍を登録する
      */
+    @Transactional
     fun execute(command: CreateBookCommand): BookDto {
         val validationErrors = validator.validate(command)
         if (validationErrors.isNotEmpty()) throw UsecaseViolationException(validationErrors)

--- a/usecase/src/main/kotlin/com/bookmanagementsystem/usecase/book/register/UpdateBookUsecase.kt
+++ b/usecase/src/main/kotlin/com/bookmanagementsystem/usecase/book/register/UpdateBookUsecase.kt
@@ -7,6 +7,7 @@ import com.bookmanagementsystem.usecase.book.read.BookDetailQueryService
 import com.bookmanagementsystem.usecase.exception.UsecaseViolationException
 import com.bookmanagementsystem.usecase.validation.CommandValidator
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 
 @Service
 class UpdateBookUsecase(
@@ -22,8 +23,9 @@ class UpdateBookUsecase(
         val currentBook =
             repository.findById(command.id) ?: throw NoSuchElementException("書籍が存在しません: ${command.id}")
 
-        val validationErrors = validator.validate(command)
-        if (validationErrors.isNotEmpty()) throw UsecaseViolationException(validationErrors)
+        validator.validate(command).let {
+            if (it.isNotEmpty()) throw UsecaseViolationException(it)
+        }
 
         val book = repository.update(toEntity(currentBook, command))
 

--- a/usecase/src/main/kotlin/com/bookmanagementsystem/usecase/book/register/UpdateBookUsecase.kt
+++ b/usecase/src/main/kotlin/com/bookmanagementsystem/usecase/book/register/UpdateBookUsecase.kt
@@ -17,6 +17,7 @@ class UpdateBookUsecase(
     /**
      * 書籍を更新する
      */
+    @Transactional
     fun execute(command: UpdateBookCommand): BookDto {
         val currentBook =
             repository.findById(command.id) ?: throw NoSuchElementException("書籍が存在しません: ${command.id}")

--- a/usecase/src/test/kotlin/com/bookmanagementsystem/usecase/author/AuthorExistsValidatorTest.kt
+++ b/usecase/src/test/kotlin/com/bookmanagementsystem/usecase/author/AuthorExistsValidatorTest.kt
@@ -1,0 +1,135 @@
+package com.bookmanagementsystem.usecase.author
+
+import com.bookmanagementsystem.domain.author.Author
+import com.bookmanagementsystem.domain.author.AuthorBirthDate
+import com.bookmanagementsystem.domain.author.AuthorRepository
+import com.bookmanagementsystem.domain.core.ID
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.clearMocks
+import io.mockk.every
+import io.mockk.mockk
+import java.time.LocalDate
+
+/**
+ * AuthorExistsValidatorのテスト
+ */
+class AuthorExistsValidatorTest : FunSpec({
+    val repository = mockk<AuthorRepository>()
+    val validator = AuthorExistsValidator(repository)
+
+    beforeEach {
+        clearMocks(repository)
+    }
+
+    context("著者存在チェックのバリデーション") {
+        test("空のリストの場合はtrue") {
+            val result = validator.isValid(emptyList(), null)
+
+            result shouldBe true
+        }
+
+        test("すべての著者IDが存在する場合はtrue") {
+            val authorId1 = ID<Author>(1)
+            val authorId2 = ID<Author>(2)
+            val authorIds = listOf(authorId1, authorId2)
+
+            val author1 = Author(
+                id = authorId1,
+                name = "著者1",
+                birthDate = AuthorBirthDate(LocalDate.of(1990, 1, 1)),
+                version = 1
+            )
+            val author2 = Author(
+                id = authorId2,
+                name = "著者2",
+                birthDate = AuthorBirthDate(LocalDate.of(1991, 2, 2)),
+                version = 1
+            )
+
+            every { repository.findByIds(authorIds) } returns listOf(author1, author2)
+
+            val result = validator.isValid(authorIds, null)
+
+            result shouldBe true
+        }
+
+        test("存在しない著者IDが含まれる場合はfalse") {
+            val authorId1 = ID<Author>(1)
+            val authorId2 = ID<Author>(999) // 存在しないID
+            val authorIds = listOf(authorId1, authorId2)
+
+            val author1 = Author(
+                id = authorId1,
+                name = "著者1",
+                birthDate = AuthorBirthDate(LocalDate.of(1990, 1, 1)),
+                version = 1
+            )
+
+            every { repository.findByIds(authorIds) } returns listOf(author1) // author2は見つからない
+
+            val result = validator.isValid(authorIds, null)
+
+            result shouldBe false
+        }
+
+        test("重複したIDが含まれる場合でも正しく検証する") {
+            val authorId1 = ID<Author>(1)
+            val authorIds = listOf(authorId1, authorId1) // 重複
+
+            val author1 = Author(
+                id = authorId1,
+                name = "著者1",
+                birthDate = AuthorBirthDate(LocalDate.of(1990, 1, 1)),
+                version = 1
+            )
+
+            every { repository.findByIds(listOf(authorId1)) } returns listOf(author1) // distinct()により重複は除去される
+
+            val result = validator.isValid(authorIds, null)
+
+            result shouldBe true
+        }
+
+        test("すべての著者IDが存在しない場合はfalse") {
+            val authorId1 = ID<Author>(998)
+            val authorId2 = ID<Author>(999)
+            val authorIds = listOf(authorId1, authorId2)
+
+            every { repository.findByIds(authorIds) } returns emptyList()
+
+            val result = validator.isValid(authorIds, null)
+
+            result shouldBe false
+        }
+
+        test("単一の存在する著者IDの場合はtrue") {
+            val authorId1 = ID<Author>(1)
+            val authorIds = listOf(authorId1)
+
+            val author1 = Author(
+                id = authorId1,
+                name = "著者1",
+                birthDate = AuthorBirthDate(LocalDate.of(1990, 1, 1)),
+                version = 1
+            )
+
+            every { repository.findByIds(authorIds) } returns listOf(author1)
+
+            val result = validator.isValid(authorIds, null)
+
+            result shouldBe true
+        }
+
+        test("単一の存在しない著者IDの場合はfalse") {
+            val authorId1 = ID<Author>(999)
+            val authorIds = listOf(authorId1)
+
+            every { repository.findByIds(authorIds) } returns emptyList()
+
+            val result = validator.isValid(authorIds, null)
+
+            result shouldBe false
+        }
+    }
+})


### PR DESCRIPTION
## 概要
書籍登録・更新時に著者IDの存在を検証するバリデーション機能を実装し、データの整合性を向上

## 詳細
### 主な変更内容
#### 3. カスタムバリデーションの実装
- `@AuthorExists`アノテーションを新規作成
- `AuthorExistsValidator`クラスで存在チェックロジックを実装

#### 5. ユースケース層の強化
- 全ユースケースクラスに`@Transactional`アノテーションを追加
- バリデーション処理の改善
- `UsecaseViolationException`のエラーメッセージ形式を統一

## 備考
- [x] テスト実施