### PR TITLE
fix: 書籍価格の最大値バリデーションを修正

### DIFF
--- a/presentation/detekt-baseline.xml
+++ b/presentation/detekt-baseline.xml
@@ -24,10 +24,10 @@
     <ID>ImportOrdering:OptimisticLockErrorResponseModel.kt$import com.fasterxml.jackson.annotation.JsonProperty import jakarta.validation.constraints.NotNull import jakarta.validation.constraints.Min import jakarta.validation.constraints.Max import jakarta.validation.constraints.Size import jakarta.validation.constraints.Pattern import jakarta.validation.Valid import com.bookmanagementsystem.usecase.author.register.PastOnly</ID>
     <ID>ImportOrdering:UpdateAuthorRequestModel.kt$import com.fasterxml.jackson.annotation.JsonProperty import jakarta.validation.constraints.NotNull import jakarta.validation.constraints.Min import jakarta.validation.constraints.Max import jakarta.validation.constraints.Size import jakarta.validation.constraints.Pattern import jakarta.validation.Valid import com.bookmanagementsystem.usecase.author.register.PastOnly</ID>
     <ID>ImportOrdering:UpdateBookRequestModel.kt$import com.fasterxml.jackson.annotation.JsonProperty import jakarta.validation.constraints.NotNull import jakarta.validation.constraints.Min import jakarta.validation.constraints.Max import jakarta.validation.constraints.Size import jakarta.validation.constraints.Pattern import jakarta.validation.Valid import com.bookmanagementsystem.usecase.author.register.PastOnly</ID>
-    <ID>MagicNumber:AuthorBookResponseModel.kt$AuthorBookResponseModel$9999999999L</ID>
-    <ID>MagicNumber:BookResponseModel.kt$BookResponseModel$9999999999L</ID>
-    <ID>MagicNumber:CreateBookRequestModel.kt$CreateBookRequestModel$9999999999L</ID>
-    <ID>MagicNumber:UpdateBookRequestModel.kt$UpdateBookRequestModel$9999999999L</ID>
+    <ID>MagicNumber:AuthorBookResponseModel.kt$AuthorBookResponseModel$99999999L</ID>
+    <ID>MagicNumber:BookResponseModel.kt$BookResponseModel$99999999L</ID>
+    <ID>MagicNumber:CreateBookRequestModel.kt$CreateBookRequestModel$99999999L</ID>
+    <ID>MagicNumber:UpdateBookRequestModel.kt$UpdateBookRequestModel$99999999L</ID>
     <ID>NoBlankLineBeforeRbrace:AuthorBookResponseModel.kt$AuthorBookResponseModel$ </ID>
     <ID>NoBlankLineBeforeRbrace:AuthorResponseModel.kt$AuthorResponseModel$ </ID>
     <ID>NoBlankLineBeforeRbrace:BadRequestErrorResponseModel.kt$BadRequestErrorResponseModel$ </ID>

--- a/presentation/src/main/kotlin/com/bookmanagementsystem/presentation/model/AuthorBookResponseModel.kt
+++ b/presentation/src/main/kotlin/com/bookmanagementsystem/presentation/model/AuthorBookResponseModel.kt
@@ -29,7 +29,7 @@ data class AuthorBookResponseModel(
 
     /* 書籍価格 */
     @get:Min(0L)
-    @get:Max(9999999999L)
+    @get:Max(99999999L)
     @field:NotNull
     @get:JsonProperty("price") val price: kotlin.Long?,
 

--- a/presentation/src/main/kotlin/com/bookmanagementsystem/presentation/model/BookResponseModel.kt
+++ b/presentation/src/main/kotlin/com/bookmanagementsystem/presentation/model/BookResponseModel.kt
@@ -31,7 +31,7 @@ data class BookResponseModel(
 
     /* 書籍価格 */
     @get:Min(0L)
-    @get:Max(9999999999L)
+    @get:Max(99999999L)
     @field:NotNull
     @get:JsonProperty("price") val price: kotlin.Long?,
 

--- a/presentation/src/main/kotlin/com/bookmanagementsystem/presentation/model/CreateBookRequestModel.kt
+++ b/presentation/src/main/kotlin/com/bookmanagementsystem/presentation/model/CreateBookRequestModel.kt
@@ -25,7 +25,7 @@ data class CreateBookRequestModel(
 
     /* 書籍価格 */
     @get:Min(0L)
-    @get:Max(9999999999L)
+    @get:Max(99999999L)
     @field:NotNull
     @get:JsonProperty("price") val price: kotlin.Long?,
 

--- a/presentation/src/main/kotlin/com/bookmanagementsystem/presentation/model/UpdateBookRequestModel.kt
+++ b/presentation/src/main/kotlin/com/bookmanagementsystem/presentation/model/UpdateBookRequestModel.kt
@@ -26,7 +26,7 @@ data class UpdateBookRequestModel(
 
     /* 書籍価格 */
     @get:Min(0L)
-    @get:Max(9999999999L)
+    @get:Max(99999999L)
     @field:NotNull
     @get:JsonProperty("price") val price: kotlin.Long?,
 

--- a/presentation/src/main/resources/openapi.yml
+++ b/presentation/src/main/resources/openapi.yml
@@ -261,7 +261,7 @@ components:
           type: integer
           format: int64
           minimum: 0
-          maximum: 9999999999
+          maximum: 99999999
           description: 書籍価格
           example: 1500
         authorIds:
@@ -293,7 +293,7 @@ components:
           type: integer
           format: int64
           minimum: 0
-          maximum: 9999999999
+          maximum: 99999999
           description: 書籍価格
           example: 1500
         authorIds:
@@ -366,7 +366,7 @@ components:
           type: integer
           format: int64
           minimum: 0
-          maximum: 9999999999
+          maximum: 99999999
           description: 書籍価格
           example: 1500
         status:
@@ -396,7 +396,7 @@ components:
           type: integer
           format: int64
           minimum: 0
-          maximum: 9999999999
+          maximum: 99999999
           description: 書籍価格
           example: 1500
         authors:

--- a/presentation/src/test/kotlin/com/bookmanagementsystem/presentation/model/CreateBookRequestModelTest.kt
+++ b/presentation/src/test/kotlin/com/bookmanagementsystem/presentation/model/CreateBookRequestModelTest.kt
@@ -238,7 +238,7 @@ class CreateBookRequestModelTest : FunSpec({
 
     test("価格が上限を超える場合バリデーションエラー") {
         val requestModel = createValidBookRequest(
-            price = 100000000L // 99999999 + 1
+            price = 99999999L + 1 // 上限値+1
         )
 
         val violations = validator.validate(requestModel)

--- a/presentation/src/test/kotlin/com/bookmanagementsystem/presentation/model/CreateBookRequestModelTest.kt
+++ b/presentation/src/test/kotlin/com/bookmanagementsystem/presentation/model/CreateBookRequestModelTest.kt
@@ -225,6 +225,26 @@ class CreateBookRequestModelTest : FunSpec({
         violations shouldHaveSize 1
         violations.first().messageTemplate shouldBe "{jakarta.validation.constraints.Pattern.message}"
     }
+
+    test("価格の境界値テスト - 最大値99999999") {
+        val requestModel = createValidBookRequest(
+            title = "高額本",
+            price = 99999999L
+        )
+
+        val violations = validator.validate(requestModel)
+        violations shouldHaveSize 0
+    }
+
+    test("価格が上限を超える場合バリデーションエラー") {
+        val requestModel = createValidBookRequest(
+            price = 100000000L // 99999999 + 1
+        )
+
+        val violations = validator.validate(requestModel)
+        violations shouldHaveSize 1
+        violations.first().messageTemplate shouldBe "{jakarta.validation.constraints.Max.message}"
+    }
 })
 
 // テストフィクスチャ

--- a/presentation/src/test/kotlin/com/bookmanagementsystem/presentation/model/UpdateBookRequestModelTest.kt
+++ b/presentation/src/test/kotlin/com/bookmanagementsystem/presentation/model/UpdateBookRequestModelTest.kt
@@ -212,6 +212,26 @@ class UpdateBookRequestModelTest : FunSpec({
         violations shouldHaveSize 1
         violations.first().messageTemplate shouldBe "{jakarta.validation.constraints.Pattern.message}"
     }
+
+    test("価格の境界値テスト - 最大値99999999") {
+        val requestModel = createValidUpdateBookRequest(
+            title = "高額本",
+            price = 99999999L
+        )
+
+        val violations = validator.validate(requestModel)
+        violations shouldHaveSize 0
+    }
+
+    test("価格が上限を超える場合バリデーションエラー") {
+        val requestModel = createValidUpdateBookRequest(
+            price = 100000000L // 99999999 + 1
+        )
+
+        val violations = validator.validate(requestModel)
+        violations shouldHaveSize 1
+        violations.first().messageTemplate shouldBe "{jakarta.validation.constraints.Max.message}"
+    }
 })
 
 // テストフィクスチャ

--- a/presentation/src/test/kotlin/com/bookmanagementsystem/presentation/model/UpdateBookRequestModelTest.kt
+++ b/presentation/src/test/kotlin/com/bookmanagementsystem/presentation/model/UpdateBookRequestModelTest.kt
@@ -225,7 +225,7 @@ class UpdateBookRequestModelTest : FunSpec({
 
     test("価格が上限を超える場合バリデーションエラー") {
         val requestModel = createValidUpdateBookRequest(
-            price = 100000000L // 99999999 + 1
+            price = 99999999L + 1 // 上限値+1
         )
 
         val violations = validator.validate(requestModel)


### PR DESCRIPTION
## 概要
書籍価格の最大値バリデーションを9999999999から99999999に修正し、より現実的な価格範囲に調整

## 詳細
### 修正理由
- **現実的な価格範囲**: 99,999,999円（約1億円）は一般的な書籍の価格範囲として適切
- **データベース制約**: より小さな数値型で十分対応可能
- **ユーザビリティ**: 過度に大きな数値による混乱を防止

## 備考
- [x] テスト実施